### PR TITLE
support for `uv` package manager

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -55,6 +55,7 @@ func All() []Manager {
 		&WindowsUpdates{},
 		&Scoop{},
 		&Maven{},
+		&Uv{},
 	}
 }
 

--- a/internal/manager/uv.go
+++ b/internal/manager/uv.go
@@ -1,0 +1,243 @@
+package manager
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+var uvHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+var uvBaseURL = "https://pypi.org"
+
+const uvMaxWorkers = 10
+
+const uvMaxRetries = 3
+
+// Uv manages Python tools installed via uv (https://docs.astral.sh/uv/).
+type Uv struct{}
+
+func (u *Uv) Name() model.Source { return model.SourceUv }
+
+func (u *Uv) Available() bool { return commandExists("uv") }
+
+func (u *Uv) Scan() ([]model.Package, error) {
+	out, err := exec.Command("uv", "tool", "list").Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseUvToolList(out)
+}
+
+// parseUvToolList parses the output of "uv tool list".
+//
+// Output format:
+//
+//	name v1.2.3
+//	- executable1
+//	- executable2
+//	another-tool v4.5.6
+//	- another-tool
+func parseUvToolList(out []byte) ([]model.Package, error) {
+	var pkgs []model.Package
+	now := time.Now()
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "-") || strings.HasPrefix(line, " ") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		ver := parts[1]
+		if strings.HasPrefix(ver, "v") {
+			ver = ver[1:]
+		}
+		if len(ver) == 0 || ver[0] < '0' || ver[0] > '9' {
+			continue
+		}
+
+		pkgs = append(pkgs, model.Package{
+			Name:        parts[0],
+			Version:     ver,
+			Source:      model.SourceUv,
+			InstalledAt: now,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return pkgs, fmt.Errorf("uv tool list: scan: %w", err)
+	}
+	return pkgs, nil
+}
+
+func (u *Uv) CheckUpdates(pkgs []model.Package) map[string]string {
+	infos := pypiVersionBatch(pkgs)
+	updates := make(map[string]string)
+	for _, p := range pkgs {
+		latest := infos[p.Name]
+		if latest != "" && latest != p.Version {
+			updates[p.Name] = latest
+		}
+	}
+	return updates
+}
+
+// Describe reads package summaries from local dist-info METADATA files
+// inside each uv tool's virtual environment. No network calls needed.
+func (u *Uv) Describe(pkgs []model.Package) map[string]string {
+	toolDir := uvToolDir()
+	if toolDir == "" {
+		return nil
+	}
+	descs := make(map[string]string, len(pkgs))
+	for _, p := range pkgs {
+		if desc := uvLocalSummary(toolDir, p.Name); desc != "" {
+			descs[p.Name] = desc
+		}
+	}
+	return descs
+}
+
+var uvToolDirOnce sync.Once
+var uvToolDirVal string
+
+func uvToolDir() string {
+	uvToolDirOnce.Do(func() {
+		out, err := exec.Command("uv", "tool", "dir").Output()
+		if err == nil {
+			uvToolDirVal = strings.TrimSpace(string(out))
+		}
+	})
+	return uvToolDirVal
+}
+
+// uvLocalSummary reads the Summary field from a tool's installed METADATA.
+// The dist-info directory uses the normalized package name (hyphens to
+// underscores) per PEP 427.
+func uvLocalSummary(toolDir, name string) string {
+	normalized := strings.ReplaceAll(name, "-", "_")
+	pattern := filepath.Join(toolDir, name, "lib", "python*", "site-packages", normalized+"-*.dist-info", "METADATA")
+	matches, err := filepath.Glob(pattern)
+	if (err != nil || len(matches) == 0) && normalized != name {
+		pattern = filepath.Join(toolDir, name, "lib", "python*", "site-packages", name+"-*.dist-info", "METADATA")
+		matches, _ = filepath.Glob(pattern)
+	}
+	if len(matches) == 0 {
+		return ""
+	}
+	return parseMetadataSummary(matches[0])
+}
+
+// parseMetadataSummary extracts the Summary field from a PEP 566 METADATA file.
+func parseMetadataSummary(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			break // End of headers, body follows.
+		}
+		if after, ok := strings.CutPrefix(line, "Summary: "); ok {
+			return after
+		}
+	}
+	return ""
+}
+
+// pypiVersionBatch fetches latest versions from PyPI concurrently.
+func pypiVersionBatch(pkgs []model.Package) map[string]string {
+	results := make(map[string]string, len(pkgs))
+	if len(pkgs) == 0 {
+		return results
+	}
+
+	var mu sync.Mutex
+	sem := make(chan struct{}, uvMaxWorkers)
+	var wg sync.WaitGroup
+
+	for _, p := range pkgs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(name string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			ver := pypiLatestVersion(name)
+			if ver != "" {
+				mu.Lock()
+				results[name] = ver
+				mu.Unlock()
+			}
+		}(p.Name)
+	}
+	wg.Wait()
+	return results
+}
+
+// pypiLatestVersion queries PyPI for the latest version of a package,
+// retrying with exponential backoff on HTTP 429 (rate limit).
+func pypiLatestVersion(name string) string {
+	apiURL := uvBaseURL + "/pypi/" + name + "/json"
+	backoff := 500 * time.Millisecond
+
+	for attempt := range uvMaxRetries {
+		resp, err := uvHTTPClient.Get(apiURL)
+		if err != nil {
+			return ""
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			resp.Body.Close()
+			if attempt < uvMaxRetries-1 {
+				time.Sleep(backoff)
+				backoff *= 2
+			}
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return ""
+		}
+
+		var result struct {
+			Info struct {
+				Version string `json:"version"`
+			} `json:"info"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if err != nil {
+			return ""
+		}
+		return result.Info.Version
+	}
+	return ""
+}
+
+func (u *Uv) UpgradeCmd(name string) *exec.Cmd {
+	return exec.Command("uv", "tool", "install", name+"@latest")
+}
+
+func (u *Uv) InstallCmd(name string) *exec.Cmd {
+	return exec.Command("uv", "tool", "install", name)
+}
+
+func (u *Uv) RemoveCmd(name string) *exec.Cmd {
+	return exec.Command("uv", "tool", "uninstall", name)
+}

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -40,6 +40,7 @@ const (
 	SourceWindowsUpdates Source = "windows-updates"
 	SourceScoop          Source = "scoop"
 	SourceMaven          Source = "maven"
+	SourceUv             Source = "uv"
 )
 
 type Package struct {

--- a/internal/ui/tabs.go
+++ b/internal/ui/tabs.go
@@ -43,6 +43,7 @@ func buildTabs(pkgs []model.Package) []tabItem {
 		{model.SourceSnap, "snap"},
 		{model.SourcePip, "pip"},
 		{model.SourcePipx, "pipx"},
+		{model.SourceUv, "uv"},
 		{model.SourceCargo, "cargo"},
 		{model.SourceGo, "go"},
 		{model.SourceNpm, "npm"},

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -89,6 +89,7 @@ func defaultManagerColorMap() map[model.Source]lipgloss.Color {
 		model.SourcePowerShell:     ColorBlue,
 		model.SourceWindowsUpdates: ColorRed,
 		model.SourceMaven:          ColorOrange,
+		model.SourceUv:             ColorPurple,
 	}
 }
 

--- a/tests/parsing/uv_pypi_test.go
+++ b/tests/parsing/uv_pypi_test.go
@@ -1,0 +1,295 @@
+package parsing
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- PyPI version fetching (mirrors pypiLatestVersion in uv.go) ---
+
+type pypiResponse struct {
+	Info struct {
+		Version string `json:"version"`
+	} `json:"info"`
+}
+
+func fetchPypiVersion(client *http.Client, baseURL, name string, maxRetries int) string {
+	url := baseURL + "/pypi/" + name + "/json"
+	backoff := 50 * time.Millisecond
+
+	for attempt := range maxRetries {
+		resp, err := client.Get(url)
+		if err != nil {
+			return ""
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			resp.Body.Close()
+			if attempt < maxRetries-1 {
+				time.Sleep(backoff)
+				backoff *= 2
+			}
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return ""
+		}
+
+		var result pypiResponse
+		err = json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if err != nil {
+			return ""
+		}
+		return result.Info.Version
+	}
+	return ""
+}
+
+func TestPypiVersionSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pypi/ruff/json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(pypiResponse{
+			Info: struct {
+				Version string `json:"version"`
+			}{
+				Version: "0.15.8",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ver := fetchPypiVersion(srv.Client(), srv.URL, "ruff", 3)
+	if ver != "0.15.8" {
+		t.Errorf("version: got %q, want %q", ver, "0.15.8")
+	}
+}
+
+func TestPypiVersionNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	ver := fetchPypiVersion(srv.Client(), srv.URL, "nonexistent", 3)
+	if ver != "" {
+		t.Errorf("expected empty version for 404, got %q", ver)
+	}
+}
+
+func TestPypiVersionRateLimitThenSuccess(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(pypiResponse{
+			Info: struct {
+				Version string `json:"version"`
+			}{
+				Version: "1.0.0",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ver := fetchPypiVersion(srv.Client(), srv.URL, "testpkg", 3)
+
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+	if ver != "1.0.0" {
+		t.Errorf("version: got %q, want %q", ver, "1.0.0")
+	}
+}
+
+func TestPypiVersionRateLimitExhausted(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	ver := fetchPypiVersion(srv.Client(), srv.URL, "testpkg", 3)
+
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+	if ver != "" {
+		t.Errorf("expected empty version after exhausting retries, got %q", ver)
+	}
+}
+
+func TestPypiVersionTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 50 * time.Millisecond}
+	ver := fetchPypiVersion(client, srv.URL, "slowpkg", 1)
+
+	if ver != "" {
+		t.Errorf("expected empty version on timeout, got %q", ver)
+	}
+}
+
+func TestPypiVersionMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"info": broken`))
+	}))
+	defer srv.Close()
+
+	ver := fetchPypiVersion(srv.Client(), srv.URL, "badpkg", 1)
+
+	if ver != "" {
+		t.Errorf("expected empty version on malformed JSON, got %q", ver)
+	}
+}
+
+func TestPypiVersionConcurrentBatch(t *testing.T) {
+	var inflight atomic.Int32
+	var maxInflight atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cur := inflight.Add(1)
+		defer inflight.Add(-1)
+
+		for {
+			old := maxInflight.Load()
+			if cur <= old || maxInflight.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+
+		time.Sleep(10 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(pypiResponse{
+			Info: struct {
+				Version string `json:"version"`
+			}{
+				Version: "1.0.0",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	const numPkgs = 25
+	const maxWorkers = 10
+
+	type pkg struct{ Name string }
+	pkgs := make([]pkg, numPkgs)
+	for i := range pkgs {
+		pkgs[i] = pkg{Name: "pkg" + string(rune('a'+i))}
+	}
+
+	results := make(map[string]string, numPkgs)
+	sem := make(chan struct{}, maxWorkers)
+	done := make(chan struct{})
+	go func() {
+		mu := new(sync.Mutex)
+		var wg sync.WaitGroup
+		for _, p := range pkgs {
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(name string) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				ver := fetchPypiVersion(srv.Client(), srv.URL, name, 1)
+				mu.Lock()
+				results[name] = ver
+				mu.Unlock()
+			}(p.Name)
+		}
+		wg.Wait()
+		close(done)
+	}()
+	<-done
+
+	if len(results) != numPkgs {
+		t.Errorf("expected %d results, got %d", numPkgs, len(results))
+	}
+	if peak := maxInflight.Load(); peak > int32(maxWorkers) {
+		t.Errorf("peak concurrency %d exceeded max workers %d", peak, maxWorkers)
+	}
+}
+
+// --- Local METADATA parsing (mirrors parseMetadataSummary in uv.go) ---
+
+func parseMetadataSummary(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			break
+		}
+		if strings.HasPrefix(line, "Summary: ") {
+			return strings.TrimPrefix(line, "Summary: ")
+		}
+	}
+	return ""
+}
+
+func TestMetadataSummaryParsing(t *testing.T) {
+	content := "Metadata-Version: 2.4\nName: posting\nVersion: 2.10.0\nSummary: The modern API client that lives in your terminal.\nProject-URL: Homepage, https://example.com\n\nLong description here.\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "METADATA")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := parseMetadataSummary(path)
+	want := "The modern API client that lives in your terminal."
+	if got != want {
+		t.Errorf("summary: got %q, want %q", got, want)
+	}
+}
+
+func TestMetadataSummaryMissing(t *testing.T) {
+	content := "Metadata-Version: 2.4\nName: nosummary\nVersion: 1.0.0\n\nBody text.\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "METADATA")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := parseMetadataSummary(path)
+	if got != "" {
+		t.Errorf("expected empty summary, got %q", got)
+	}
+}
+
+func TestMetadataSummaryFileNotFound(t *testing.T) {
+	got := parseMetadataSummary("/nonexistent/METADATA")
+	if got != "" {
+		t.Errorf("expected empty summary for missing file, got %q", got)
+	}
+}

--- a/tests/parsing/uv_test.go
+++ b/tests/parsing/uv_test.go
@@ -1,0 +1,82 @@
+package parsing
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// parseUvToolList mirrors the parsing logic in internal/manager/uv.go.
+func parseUvToolList(out []byte) []struct{ name, version string } {
+	type pkg = struct{ name, version string }
+	var pkgs []pkg
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "-") || strings.HasPrefix(line, " ") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		ver := parts[1]
+		if strings.HasPrefix(ver, "v") {
+			ver = ver[1:]
+		}
+		if len(ver) == 0 || ver[0] < '0' || ver[0] > '9' {
+			continue
+		}
+		pkgs = append(pkgs, pkg{parts[0], ver})
+	}
+	return pkgs
+}
+
+func TestUvToolListParsing(t *testing.T) {
+	output := []byte(`posting v2.10.0
+- posting
+ruff v0.15.8
+- ruff
+black v24.4.2
+- black
+- blackd
+`)
+	pkgs := parseUvToolList(output)
+
+	if len(pkgs) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(pkgs))
+	}
+
+	expected := []struct{ name, version string }{
+		{"posting", "2.10.0"},
+		{"ruff", "0.15.8"},
+		{"black", "24.4.2"},
+	}
+	for i, exp := range expected {
+		if pkgs[i].name != exp.name || pkgs[i].version != exp.version {
+			t.Errorf("pkg %d: got %+v, want %+v", i, pkgs[i], exp)
+		}
+	}
+}
+
+func TestUvToolListEmpty(t *testing.T) {
+	output := []byte("No tools installed\n")
+	pkgs := parseUvToolList(output)
+
+	if len(pkgs) != 0 {
+		t.Fatalf("expected 0 tools from empty output, got %d", len(pkgs))
+	}
+}
+
+func TestUvToolListVersionWithoutPrefix(t *testing.T) {
+	output := []byte("mytool 1.0.0\n- mytool\n")
+	pkgs := parseUvToolList(output)
+
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(pkgs))
+	}
+	if pkgs[0].name != "mytool" || pkgs[0].version != "1.0.0" {
+		t.Errorf("got %+v, want {mytool 1.0.0}", pkgs[0])
+	}
+}


### PR DESCRIPTION
## Summary

  - Add `uv` package manager support with `Manager`, `UpdateChecker`, `Describer`, `Upgrader`, `Installer`, and `Remover` interfaces, 
  - the `uv` manager is missing: Searcher, DeepRemover, DependencyLister
  - Parse `uv tool list` for installed packages


<img width="1552" height="377" alt="Screenshot 2026-03-27 at 09 31 52" src="https://github.com/user-attachments/assets/43341c5e-dbae-4340-9a6e-5c033ae7b746" />


  ### uv vs pip

  | | uv | pip |
  |---|---|---|
  | **Descriptions** | Local METADATA files (instant) | `pip show` subprocess per pkg |
  | **Update checks** | HTTP to PyPI, 10 concurrent | `pip list --outdated` (single subprocess) |
  | **Offline support** | Descriptions: yes. Updates: no | Both work offline |

  ### Assumptions

  - uv tools are published on PyPI (JSON API is the sole source for latest versions)
  - dist-info directories follow PEP 427 naming; falls back to hyphenated names
  - PyPI rate limits are lenient for typical tool counts (~10–200)

  ### Drawbacks

  - Update checks require network — no offline fallback unlike pip
  - Check updates via PyPI JSON API with bounded concurrency (10 workers) and exponential backoff on 429
  - Large PyPI JSON responses are streamed but fully decoded (no lightweight endpoint exists)
  - First cold-cache update check with many tools is slower than pip's local `--outdated`

Shipped with the help of Claude Code /w Opus 4.6

If you have any design changes let me know, this is part of #32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Python tools managed by `uv`. Users can now discover, display, and manage `uv`-installed packages alongside other package managers.
  * New UI tab displays `uv` packages when present, with update checking and descriptions from package metadata.
  * Support for upgrade, install, and removal operations on `uv` packages.

* **Tests**
  * Added comprehensive test coverage for `uv` parsing and PyPI version fetching logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->