### PR TITLE
Fix post-merge issues flagged by CodeRabbit on #43

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -439,14 +439,6 @@ func scanManagerCmds() []tea.Cmd {
 	return cmds
 }
 
-// startFreshScan emits the start message followed by per-manager scan commands.
-func startFreshScan() tea.Cmd {
-	cmds := append([]tea.Cmd{func() tea.Msg {
-		return scanStartMsg{total: availableManagerCount()}
-	}}, scanManagerCmds()...)
-	return tea.Batch(cmds...)
-}
-
 // forceRescan always does a live scan, ignoring cache.
 func forceRescan() tea.Msg {
 	return scanStartMsg{total: availableManagerCount()}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1416,9 +1416,12 @@ func (m Model) View() string {
 	}
 
 	// Status bar. Detail and search views own their own keybind bar (centered
-	// inside their render functions), so we skip the status bar and its
-	// separator rule in those views to avoid duplicate hints.
-	if m.view != viewDetail && m.view != viewSearch {
+	// inside their render functions), so we skip the keybind help in those
+	// views to avoid duplicate hints — but still show m.statusMsg if one is
+	// set, otherwise transient messages (operation errors, progress) silently
+	// disappear while the user is looking at a package detail or search.
+	showKeybinds := m.view != viewDetail && m.view != viewSearch
+	if showKeybinds || m.statusMsg != "" {
 		b.WriteString("\n")
 		b.WriteString(StyleDim.Render("  " + strings.Repeat("─", min(m.width-4, 120))))
 		b.WriteString("\n")

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -301,6 +301,7 @@ type Model struct {
 	scanCompleted  int
 	scanAccum      []model.Package
 	scanCurrentMgr string
+	scanErrored    bool
 
 	// Title intro animation. `titleReveal` is the number of characters of
 	// "GlazePKG" currently visible; tea.Tick increments it on mount until
@@ -822,15 +823,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case scanStartMsg:
+		cmds := scanManagerCmds()
+		if len(cmds) == 0 {
+			// No available managers — don't leave the UI pinned in the
+			// "scanning" state forever. Emit an empty scanDoneMsg directly.
+			return m, func() tea.Msg { return scanDoneMsg{} }
+		}
 		m.scanning = true
 		m.scanTotal = msg.total
 		m.scanCompleted = 0
 		m.scanAccum = m.scanAccum[:0]
 		m.scanCurrentMgr = ""
-		return m, tea.Batch(scanManagerCmds()...)
+		m.scanErrored = false
+		return m, tea.Batch(cmds...)
 
 	case scanManagerDoneMsg:
-		if msg.err == nil {
+		if msg.err != nil {
+			m.scanErrored = true
+		} else {
 			m.scanAccum = append(m.scanAccum, msg.pkgs...)
 		}
 		m.scanCompleted++
@@ -838,9 +848,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.scanCompleted >= m.scanTotal {
 			pkgs := m.scanAccum
 			m.scanAccum = nil
+			errored := m.scanErrored
 			return m, func() tea.Msg {
 				sort.Slice(pkgs, func(i, j int) bool { return pkgs[i].Name < pkgs[j].Name })
-				manager.SaveScanCache(pkgs)
+				// Only persist the cache when every manager scanned cleanly.
+				// Otherwise a transient failure would be frozen into the
+				// cache and the missing packages would stay invisible until
+				// the user forces a rescan.
+				if !errored {
+					manager.SaveScanCache(pkgs)
+				}
 				return scanDoneMsg{pkgs: pkgs}
 			}
 		}

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -253,10 +253,12 @@ func detailKeybinds(m *Model) string {
 		}
 	default:
 		// Mirror the capability checks the key handler uses, so we don't
-		// advertise keys that the current package can't actually act on
-		// (e.g. showing "u upgrade" for a manager with no Upgrader impl,
-		// or "d deps" on a package with no dependency data).
-		if mgr := manager.BySource(m.detailPkg.Source); mgr != nil {
+		// advertise keys that the current package can't actually act on:
+		// hide u/x when the manager lacks the interface OR is currently
+		// unavailable (the handler would otherwise bail out with a
+		// "not available" status message), and hide d when there is no
+		// dependency data to show.
+		if mgr := manager.BySource(m.detailPkg.Source); mgr != nil && mgr.Available() {
 			if _, ok := mgr.(manager.Upgrader); ok {
 				pairs = append(pairs, struct{ key, desc string }{"u", "upgrade"})
 			}

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/neur0map/glazepkg/internal/manager"
 	"github.com/neur0map/glazepkg/internal/model"
 )
 
@@ -251,15 +252,27 @@ func detailKeybinds(m *Model) string {
 			{"j/k", "navigate"}, {"esc", "close"},
 		}
 	default:
-		pairs = []struct{ key, desc string }{
-			{"u", "upgrade"},
-			{"x", "remove"},
-			{"e", "edit"},
-			{"d", "deps"},
-			{"h", "help"},
-			{"esc", "back"},
-			{"q", "quit"},
+		// Mirror the capability checks the key handler uses, so we don't
+		// advertise keys that the current package can't actually act on
+		// (e.g. showing "u upgrade" for a manager with no Upgrader impl,
+		// or "d deps" on a package with no dependency data).
+		if mgr := manager.BySource(m.detailPkg.Source); mgr != nil {
+			if _, ok := mgr.(manager.Upgrader); ok {
+				pairs = append(pairs, struct{ key, desc string }{"u", "upgrade"})
+			}
+			if _, ok := mgr.(manager.Remover); ok {
+				pairs = append(pairs, struct{ key, desc string }{"x", "remove"})
+			}
 		}
+		pairs = append(pairs, struct{ key, desc string }{"e", "edit"})
+		if len(m.detailPkg.DependsOn) > 0 || len(m.detailPkg.RequiredBy) > 0 {
+			pairs = append(pairs, struct{ key, desc string }{"d", "deps"})
+		}
+		pairs = append(pairs,
+			struct{ key, desc string }{"h", "help"},
+			struct{ key, desc string }{"esc", "back"},
+			struct{ key, desc string }{"q", "quit"},
+		)
 	}
 
 	var parts []string

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -19,7 +19,7 @@ func helpBody() string {
 		{"PgDn/PgUp", "Page down/up"},
 		{"Tab/Shift+Tab", "Cycle manager tabs"},
 		{"/ or Ctrl+f", "Fuzzy search"},
-		{"Esc", "Clear search / close overlay"},
+		{"Esc", "Clear search / close modal"},
 		{"Enter", "Package details"},
 		{"u (detail)", "Upgrade package"},
 		{"x (detail)", "Remove package"},

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -412,9 +412,14 @@ func renderDepsModalBody(m *Model) ModalFrameOpts {
 
 func handlePkgHelpModalKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := normalizeHotkey(msg.String())
-	// Must match pkgHelpBody's visibleLines = m.height - 10 so the final
-	// lines of `<pkg> --help` output are actually reachable by scrolling.
-	maxScroll := len(m.pkgHelpLines) - (m.height - 10)
+	// Must match pkgHelpBody's visibleLines (including its min-5 floor)
+	// so the final lines of `<pkg> --help` output are actually reachable,
+	// even on very small terminals where m.height - 10 would underflow.
+	visible := m.height - 10
+	if visible < 5 {
+		visible = 5
+	}
+	maxScroll := len(m.pkgHelpLines) - visible
 	if maxScroll < 0 {
 		maxScroll = 0
 	}

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -412,7 +412,9 @@ func renderDepsModalBody(m *Model) ModalFrameOpts {
 
 func handlePkgHelpModalKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := normalizeHotkey(msg.String())
-	maxScroll := len(m.pkgHelpLines) - (m.height - 8)
+	// Must match pkgHelpBody's visibleLines = m.height - 10 so the final
+	// lines of `<pkg> --help` output are actually reachable by scrolling.
+	maxScroll := len(m.pkgHelpLines) - (m.height - 10)
 	if maxScroll < 0 {
 		maxScroll = 0
 	}

--- a/internal/ui/multiselect.go
+++ b/internal/ui/multiselect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 
@@ -355,7 +356,7 @@ func batchConfirmBody(m *Model) string {
 	}
 
 	// --- Header (always visible) ---
-	header := StyleNormal.Render(fmt.Sprintf("%s %d packages?", strings.Title(batch.op), len(batch.ops)))
+	header := StyleNormal.Render(fmt.Sprintf("%s %d packages?", batchOpTitle(batch.op), len(batch.ops)))
 
 	// --- Package list (scrollable region) ---
 	var privPkgs, unprivPkgs []batchOp
@@ -372,13 +373,7 @@ func batchConfirmBody(m *Model) string {
 		warnStyle := lipgloss.NewStyle().Foreground(ColorYellow)
 		listBuf.WriteString(warnStyle.Render("privileged (1 password for all):"))
 		listBuf.WriteString("\n")
-		bySource := make(map[model.Source][]string)
-		for _, o := range privPkgs {
-			bySource[o.pkg.Source] = append(bySource[o.pkg.Source], o.pkg.Name)
-		}
-		for src, names := range bySource {
-			listBuf.WriteString(formatSourceNameList(string(src), names, wrapW))
-		}
+		writeSortedSourceLists(&listBuf, privPkgs, wrapW)
 	}
 	if len(unprivPkgs) > 0 {
 		if listBuf.Len() > 0 {
@@ -386,13 +381,7 @@ func batchConfirmBody(m *Model) string {
 		}
 		listBuf.WriteString(StyleDim.Render("unprivileged:"))
 		listBuf.WriteString("\n")
-		bySource := make(map[model.Source][]string)
-		for _, o := range unprivPkgs {
-			bySource[o.pkg.Source] = append(bySource[o.pkg.Source], o.pkg.Name)
-		}
-		for src, names := range bySource {
-			listBuf.WriteString(formatSourceNameList(string(src), names, wrapW))
-		}
+		writeSortedSourceLists(&listBuf, unprivPkgs, wrapW)
 	}
 	if len(batch.skipped) > 0 {
 		if listBuf.Len() > 0 {
@@ -502,6 +491,41 @@ func sliceScrollable(lines []string, scroll, maxH int) (visible []string, scroll
 	return visible, scrollHint
 }
 
+
+// batchOpTitle returns the Title-Case label for a known batch op verb.
+// Avoids strings.Title (deprecated in Go 1.18+) for a small closed set of
+// values we control.
+func batchOpTitle(op string) string {
+	switch op {
+	case "upgrade":
+		return "Upgrade"
+	case "remove":
+		return "Remove"
+	default:
+		return op
+	}
+}
+
+// writeSortedSourceLists groups ops by manager source, then writes them in
+// a deterministic order: sources alphabetical, names alphabetical within
+// each source. Needed because ranging over the intermediate map would
+// otherwise shuffle the package list between renders.
+func writeSortedSourceLists(buf *strings.Builder, ops []batchOp, wrapW int) {
+	bySource := make(map[model.Source][]string)
+	for _, o := range ops {
+		bySource[o.pkg.Source] = append(bySource[o.pkg.Source], o.pkg.Name)
+	}
+	sources := make([]model.Source, 0, len(bySource))
+	for src := range bySource {
+		sources = append(sources, src)
+	}
+	sort.Slice(sources, func(i, j int) bool { return string(sources[i]) < string(sources[j]) })
+	for _, src := range sources {
+		names := bySource[src]
+		sort.Strings(names)
+		buf.WriteString(formatSourceNameList(string(src), names, wrapW))
+	}
+}
 
 // formatSourceNameList renders "  <src>: a, b, c, d" with continuation lines
 // indented to align under the first name so long package lists wrap cleanly


### PR DESCRIPTION
Follow-up to #43. Systematic review of the CodeRabbit feedback surfaced 7 real bugs or dead-code issues that CI did not catch because they are UI-behavior or edge-case issues, not test/compile failures. Each is fixed in its own commit with the reasoning in the commit body.

## Bugs fixed

1. **pkg-help modal scrolls stop 2 lines early** — `handlePkgHelpModalKey` used `m.height - 8` as its scroll budget, but `pkgHelpBody` renders with `m.height - 10`. The last two lines of long `--help` output were unreachable.

2. **Status messages silenced in detail / search views** — the condition that skipped the keybind status bar in those views also skipped `m.statusMsg`, so transient messages (operation errors, filter hints) disappeared while the user was on a detail screen.

3. **Scan cache persisted on partial failure** — if any manager scan errored, its packages were correctly skipped from the in-memory accumulator, but the partial result was still written to disk. A transient failure would freeze into the cache until a manual rescan.

4. **UI stuck when no managers are available** — `scanStartMsg` flipped into the scanning state and ran `scanManagerCmds()`. If that returned empty, `scanManagerDoneMsg` never fired and the UI stayed in the scanning state forever. Now short-circuits via `scanDoneMsg{}`.

5. **Dead / double-running `startFreshScan`** — the helper was never called anywhere, and if it had been it would have double-run scans (batches `scanManagerCmds()` AND emits `scanStartMsg` whose handler re-runs `scanManagerCmds()`). Removed.

6. **Non-deterministic batch confirm order** — the privileged / unprivileged package lists ranged over `map[model.Source][]string` directly, so Go's randomized map iteration shuffled the order between renders. Now sorted by source then name.

7. **Deprecated `strings.Title`** — replaced with a small `batchOpTitle` helper over the closed set of valid op verbs.

8. **Detail-view footer advertised unusable keys** — hardcoded \"u upgrade / x remove / d deps\" even for managers with no Upgrader/Remover or packages with no deps. Now mirrors the key handler's capability checks.

9. **Stale \"overlay\" wording in help modal** — fixed to \"modal\" to match the subsystem naming.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./tests/parsing/...`
- [x] `go test ./internal/ui/...`
- [x] Integration tests on macOS + Linux (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed scrolling to view complete package help content
* Status messages now consistently visible across all views
* Enhanced error handling during package scans

## UX Improvements
* Display context-aware keyboard shortcuts based on package capabilities
* Deterministic ordering of package lists
* Updated help text labels for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->