### PR TITLE
Fix self-update on Windows (closes #44)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/muesli/termenv v0.16.0
 	github.com/sahilm/fuzzy v0.1.1
+	golang.org/x/sys v0.38.0
 )
 
 require (
@@ -31,6 +32,5 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
 github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
@@ -18,6 +20,8 @@ github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF
 github.com/charmbracelet/x/ansi v0.11.6/go.mod h1:2JNYLgQUsyqaiLovhU2Rv/pb8r6ydXKS3NIttu3VGZQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/clipperhouse/displaywidth v0.9.0 h1:Qb4KOhYwRiN3viMv1v/3cTBlz3AcAZX3+y9OLhMtAtA=

--- a/internal/updater/replace_unix.go
+++ b/internal/updater/replace_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package updater
+
+// replaceBinary overwrites dest with src. On Unix the running process keeps
+// the old inode open via its existing file descriptor, so a straight atomic
+// rename is safe even while gpk is still running.
+func replaceBinary(src, dest string) error {
+	return moveFile(src, dest)
+}

--- a/internal/updater/replace_windows.go
+++ b/internal/updater/replace_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package updater
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// replaceBinary performs the "rename running exe" dance required to swap a
+// running gpk.exe on Windows:
+//
+//  1. Windows refuses to overwrite or delete an executable that is currently
+//     running, but it will happily *rename* it. Move the current binary to
+//     "<dest>.old" to free its path.
+//  2. Move the new binary into the now-vacant destination path.
+//  3. Try to remove the old binary immediately. If Windows still has it
+//     locked (the current process's image), schedule it for deletion on the
+//     next reboot via MoveFileEx(..., MOVEFILE_DELAY_UNTIL_REBOOT) so we
+//     don't leave stale ".old" files piling up.
+//
+// Any write step that fails with a permission error propagates up so the
+// caller (wrapReplaceErr) can render the "re-run the installer as admin"
+// guidance — the dance still needs write access to the install directory.
+func replaceBinary(src, dest string) error {
+	oldPath := dest + ".old"
+	_ = os.Remove(oldPath) // best-effort cleanup of a stale .old from a prior update
+
+	if err := os.Rename(dest, oldPath); err != nil {
+		return fmt.Errorf("rename current binary: %w", err)
+	}
+	if err := moveFile(src, dest); err != nil {
+		_ = os.Rename(oldPath, dest) // roll back so the user isn't left with nothing at dest
+		return fmt.Errorf("install new binary: %w", err)
+	}
+	if err := os.Remove(oldPath); err != nil {
+		scheduleDeleteOnReboot(oldPath)
+	}
+	return nil
+}
+
+func scheduleDeleteOnReboot(path string) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return
+	}
+	_ = windows.MoveFileEx(p, nil, windows.MOVEFILE_DELAY_UNTIL_REBOOT)
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -2,15 +2,20 @@ package updater
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
-	"strings"
 )
 
-const repoAPI = "https://api.github.com/repos/neur0map/glazepkg/releases/latest"
+const (
+	repoAPI     = "https://api.github.com/repos/neur0map/glazepkg/releases/latest"
+	releasesURL = "https://github.com/neur0map/glazepkg/releases/latest"
+)
 
 type ghRelease struct {
 	TagName string    `json:"tag_name"`
@@ -60,7 +65,6 @@ func Update(currentVersion string) (string, error) {
 	if err != nil {
 		return latest, fmt.Errorf("cannot find current binary path: %w", err)
 	}
-	// Resolve symlinks
 	resolved, err := resolveExecPath(execPath)
 	if err != nil {
 		return latest, err
@@ -114,40 +118,100 @@ func resolveExecPath(execPath string) (string, error) {
 	return execPath, nil
 }
 
+// downloadAndReplace stages the new binary in the system temp directory and
+// then hands off to the platform-specific replaceBinary. Staging in os.TempDir
+// rather than beside the destination means the download itself never needs
+// write access to the install directory — we only need that permission for
+// the final swap, and any failure there produces a clear, actionable error.
 func downloadAndReplace(url, destPath string) error {
+	tmpPath, err := stageDownload(url)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpPath) // no-op once replaceBinary succeeds
+
+	if err := replaceBinary(tmpPath, destPath); err != nil {
+		return wrapReplaceErr(err, destPath)
+	}
+	return nil
+}
+
+// stageDownload streams url into a new file in the system temp dir and
+// returns its path. Caller is responsible for removing it.
+func stageDownload(url string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		return fmt.Errorf("download failed: %w", err)
+		return "", fmt.Errorf("download failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("download returned %s", resp.Status)
+		return "", fmt.Errorf("download returned %s", resp.Status)
 	}
 
-	// Write to a temp file next to the binary, then atomic rename
-	tmpPath := destPath + ".tmp"
-	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	f, err := os.CreateTemp("", "gpk-update-*")
 	if err != nil {
-		// If we can't write next to it, might need sudo
-		if strings.Contains(err.Error(), "permission denied") {
-			return fmt.Errorf("permission denied — try: sudo gpk update")
-		}
-		return fmt.Errorf("cannot create temp file: %w", err)
+		return "", fmt.Errorf("cannot stage download: %w", err)
 	}
+	tmpPath := f.Name()
 
 	if _, err := io.Copy(f, resp.Body); err != nil {
 		f.Close()
 		os.Remove(tmpPath)
-		return fmt.Errorf("download interrupted: %w", err)
+		return "", fmt.Errorf("download interrupted: %w", err)
 	}
-	f.Close()
-
-	// Atomic replace
-	if err := os.Rename(tmpPath, destPath); err != nil {
+	// Best effort — some filesystems (Windows) ignore unix-style mode bits.
+	_ = f.Chmod(0o755)
+	if err := f.Close(); err != nil {
 		os.Remove(tmpPath)
+		return "", fmt.Errorf("cannot close staged file: %w", err)
+	}
+	return tmpPath, nil
+}
+
+// moveFile renames src to dest, falling back to copy+remove when rename
+// fails (e.g. cross-device on Linux when os.TempDir is a different mount
+// than the install directory).
+func moveFile(src, dest string) error {
+	if err := os.Rename(src, dest); err == nil {
+		return nil
+	}
+
+	srcF, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcF.Close()
+
+	destF, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(destF, srcF); err != nil {
+		destF.Close()
+		os.Remove(dest)
+		return err
+	}
+	if err := destF.Close(); err != nil {
+		os.Remove(dest)
+		return err
+	}
+	return os.Remove(src)
+}
+
+// wrapReplaceErr turns raw permission errors into platform-appropriate
+// guidance. Uses errors.Is against fs.ErrPermission so it works on every
+// OS — the previous string match ("permission denied") never fired on
+// Windows, where os.OpenFile returns "Access is denied".
+func wrapReplaceErr(err error, destPath string) error {
+	if !errors.Is(err, fs.ErrPermission) {
 		return fmt.Errorf("cannot replace binary: %w", err)
 	}
-
-	return nil
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf(
+			"cannot write to %s — download the latest installer from %s and run it to update",
+			filepath.Dir(destPath), releasesURL,
+		)
+	}
+	return fmt.Errorf("permission denied writing %s — try: sudo gpk update", destPath)
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,151 @@
+package updater
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestWrapReplaceErr_NonPermissionErrorPassesThrough(t *testing.T) {
+	got := wrapReplaceErr(errors.New("disk full"), "/tmp/gpk")
+	if got == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(got.Error(), "cannot replace binary") {
+		t.Errorf("expected 'cannot replace binary' wrapper, got %q", got)
+	}
+	if !strings.Contains(got.Error(), "disk full") {
+		t.Errorf("expected original cause in chain, got %q", got)
+	}
+}
+
+func TestWrapReplaceErr_PermissionIsDetectedOnEveryPlatform(t *testing.T) {
+	// os.PathError{ Err: fs.ErrPermission } is the shape os.OpenFile
+	// returns on every OS; this is the exact failure mode that used to
+	// slip past the old string match on Windows.
+	pathErr := &fs.PathError{Op: "open", Path: "/fake", Err: fs.ErrPermission}
+	got := wrapReplaceErr(pathErr, `C:\Program Files\gpk\gpk.exe`)
+	if got == nil {
+		t.Fatal("expected a wrapped permission error")
+	}
+	msg := got.Error()
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(msg, "installer") {
+			t.Errorf("windows branch should point at the installer, got %q", msg)
+		}
+		if strings.Contains(msg, "sudo") {
+			t.Errorf("windows branch should not suggest sudo, got %q", msg)
+		}
+	} else {
+		if !strings.Contains(msg, "sudo gpk update") {
+			t.Errorf("unix branch should suggest sudo, got %q", msg)
+		}
+	}
+}
+
+func TestMoveFile_RenamesWithinSameDirectory(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dest := filepath.Join(dir, "dest")
+	if err := os.WriteFile(src, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := moveFile(src, dest); err != nil {
+		t.Fatalf("moveFile: %v", err)
+	}
+
+	if _, err := os.Stat(src); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("src should be gone after move, got err=%v", err)
+	}
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("dest content = %q, want %q", body, "hello")
+	}
+}
+
+func TestMoveFile_OverwritesExistingDest(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dest := filepath.Join(dir, "dest")
+	if err := os.WriteFile(src, []byte("new"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dest, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+
+	if err := moveFile(src, dest); err != nil {
+		t.Fatalf("moveFile: %v", err)
+	}
+
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(body) != "new" {
+		t.Errorf("dest should contain new content, got %q", body)
+	}
+}
+
+func TestStageDownload_WritesBodyToTempFile(t *testing.T) {
+	payload := "fake binary contents"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, payload)
+	}))
+	defer srv.Close()
+
+	path, err := stageDownload(srv.URL)
+	if err != nil {
+		t.Fatalf("stageDownload: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(path) })
+
+	if !strings.HasPrefix(filepath.Base(path), "gpk-update-") {
+		t.Errorf("temp file name should carry the gpk-update- prefix, got %q", filepath.Base(path))
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read temp file: %v", err)
+	}
+	if string(body) != payload {
+		t.Errorf("staged body = %q, want %q", body, payload)
+	}
+}
+
+func TestStageDownload_ReportsNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if _, err := stageDownload(srv.URL); err == nil {
+		t.Fatal("expected error on 404 response")
+	} else if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should mention the status code, got %q", err)
+	}
+}
+
+func TestBinaryName_MatchesCurrentPlatform(t *testing.T) {
+	got := binaryName()
+	wantPrefix := "gpk-" + runtime.GOOS + "-" + runtime.GOARCH
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("binaryName() = %q, want prefix %q", got, wantPrefix)
+	}
+	if runtime.GOOS == "windows" && !strings.HasSuffix(got, ".exe") {
+		t.Errorf("windows binary name should end in .exe, got %q", got)
+	}
+	if runtime.GOOS != "windows" && strings.HasSuffix(got, ".exe") {
+		t.Errorf("non-windows binary name should not end in .exe, got %q", got)
+	}
+}


### PR DESCRIPTION
closes #44

`gpk update` on a windows install under `C:\Program Files\gpk\` was failing before it even got to the interesting part — it opened `<exe>.tmp` next to the binary to stage the download, which obviously can't succeed in Program Files without elevation. and even if that worked, the "permission denied" substring match in the error branch only fires on unix, so windows users were getting the raw `Access is denied` OS error with no guidance. and even if *that* worked, windows won't let you overwrite a running .exe anyway.

so: stage into `os.TempDir()`, use `errors.Is(err, fs.ErrPermission)` for detection, branch the message on GOOS (windows → point at the installer url, unix → sudo), and split replaceBinary per-platform. windows does the rename-running-exe-to-.old dance and schedules the .old for delete-on-reboot via MoveFileEx.