### PR TITLE
Add headless commands for scripts and CI (closes #56)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Tag to release (e.g. v0.4.0). Blank = auto-bump patch.'
+        description: 'Tag to release (e.g. v0.5.0). Blank = auto-bump patch, or honor a "release-as: vX.Y.Z" line in the head commit message.'
         required: false
         default: ''
       release_name:
@@ -40,10 +40,21 @@ jobs:
         id: bump
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
+          # Precedence:
+          #   1. workflow_dispatch input (explicit, wins)
+          #   2. a "release-as: vX.Y.Z" line in the head commit message
+          #   3. auto-bump the patch component of the latest tag
+          if [ -z "$INPUT_VERSION" ]; then
+            INPUT_VERSION=$(printf '%s' "$COMMIT_MESSAGE" \
+              | grep -oE 'release-as:[[:space:]]*v?[0-9]+\.[0-9]+\.[0-9]+' \
+              | head -n1 \
+              | sed -E 's/.*release-as:[[:space:]]*//')
+          fi
           if [ -n "$INPUT_VERSION" ]; then
-            tag="$INPUT_VERSION"
-            ver="${tag#v}"
+            ver="${INPUT_VERSION#v}"
+            tag="v${ver}"
           else
             latest=$(git tag -l 'v*' --sort=-v:refname | head -n1)
             if [ -z "$latest" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: go vet ./...
 
       - name: Unit tests
-        run: go test ./tests/parsing/... -v
+        run: go test ./tests/parsing/... ./internal/cli/... -v
 
   integration-macos:
     runs-on: macos-latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ PLAN.md
 docs/
 
 .claude/
+.worktrees/

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,100 +1,128 @@
 # Manager Compatibility
 
-Reference for which package managers support which headless write operations (`gpk install` / `remove` / `upgrade`), and what command each one constructs. This is the source of truth for `gpk`'s cross-OS coverage claims.
+What `gpk` can do per package manager, and the OS each manager runs on. This is the source-of-truth reference for both the TUI and headless CLI.
 
-> **Regenerating this doc:** the matrix is derived from the manager interfaces in `internal/manager/`. To re-run the audit and see fresh output:
+> **Regenerating the matrix:** the table is derived from the Go interfaces in `internal/manager/`. To re-run the audit:
 > ```bash
 > go test ./tests/integration/... -run TestManagerCapabilityMatrix -v
 > go test ./tests/integration/... -run TestManagerCommandSamples -v
 > ```
 
-## How to read the matrix
+## What gpk can do
 
-Each column reports whether the manager implements the matching Go interface in `internal/manager/`:
+Every operation `gpk` exposes maps to one Go interface in `internal/manager/`. A manager supports the operation iff it implements that interface. **TUI and headless use the same interfaces** — anything you can do in the TUI you can do from `gpk <subcommand>`, and vice versa.
 
-| Column | Interface | What it controls |
-|---|---|---|
-| `Inst` | `Installer` | `gpk install <pkg>` |
-| `Inst+y` | `NonInteractiveInstaller` | `gpk install <pkg> --yes` skips the manager's own prompt |
-| `Up` | `Upgrader` | `gpk upgrade <pkg>` |
-| `Up+y` | `NonInteractiveUpgrader` | `gpk upgrade <pkg> --yes` |
-| `Rm` | `Remover` | `gpk remove <pkg>` |
-| `Rm+y` | `NonInteractiveRemover` | `gpk remove <pkg> --yes` |
-| `Deep` | `DeepRemover` | `gpk remove <pkg> --with-deps` |
-| `Deep+y` | `NonInteractiveDeepRemover` | `gpk remove <pkg> --with-deps --yes` |
+| Operation | TUI | Headless | Interface | Coverage |
+|---|---|---|---|---|
+| List installed packages | the package table | `gpk list` | `Manager.Scan` | **37 / 37** |
+| Package details | `Enter` → detail view | `gpk info <pkg>` | `Manager.Scan` (base) + `Describer` (description) | base 37 / 37; rich desc 34 / 37 |
+| Dependency tree | `d` in detail | _(detail-only)_ | `DependencyLister` | 23 / 37 |
+| Which manager has it | source pill in row | `gpk source-of <pkg>` | `Manager.Scan` | 37 / 37 |
+| Update detection (`↑`) | indicator in row | `gpk outdated` / `--count` / `--exit-code` | `UpdateChecker` | 28 / 37 |
+| Install search (catalog) | `i` → search overlay | `gpk install <pkg>` (resolution step) | `Searcher` | 25 / 37 |
+| Install | search → install confirm | `gpk install <pkg>` | `Installer` | 34 / 37 |
+| Install non-interactive | _(uses modal)_ | `gpk install --yes` | `NonInteractiveInstaller` *(see note)* | 5 / 37 explicit; the rest are no-ops |
+| Upgrade single | `u` in detail | `gpk upgrade <pkg>` | `Upgrader` | 36 / 37 |
+| Upgrade non-interactive | _(uses modal)_ | `gpk upgrade --yes` | `NonInteractiveUpgrader` *(see note)* | 5 / 37 explicit |
+| Remove | `x` in detail | `gpk remove <pkg>` | `Remover` | 35 / 37 |
+| Remove non-interactive | _(uses modal)_ | `gpk remove --yes` | `NonInteractiveRemover` *(see note)* | 5 / 37 explicit |
+| Remove + deps | remove modal "deep" option | `gpk remove --with-deps` | `DeepRemover` | 4 / 37 (pacman, apt, dnf, xbps) |
+| Snapshots / diff / export | `s` / `d` / `e` | _(TUI-only in Phase 1)_ | filesystem (no manager interface) | universal |
+| Fuzzy filter | `/` over the table | _(implicit via `gpk list` + pipe)_ | client-side | universal |
+| Theme picker | `t` | _(N/A)_ | reads `~/.config/glazepkg/themes/*.toml` | universal |
+| User notes (custom descriptions) | `e` in detail | _(TUI-only in Phase 1)_ | persists to `~/.local/share/glazepkg/notes.json` | universal |
 
-A `✓` means the interface is implemented; `─` means it isn't, and `gpk` falls back gracefully (interactive command for `+y`, error message for unsupported ops).
-
-## TUI vs headless coverage
-
-The TUI (`gpk` with no args) and the headless commands share the **same** manager interfaces — there's no manager that the TUI supports but headless doesn't, or vice versa.
-
-| Operation | TUI surface | Headless surface | Interface both call |
-|---|---|---|---|
-| Install | Search panel (`i`) → result row → install confirmation | `gpk install <pkg>` | `manager.Installer.InstallCmd` |
-| Upgrade | Detail view (`Enter`) → `u` | `gpk upgrade <pkg>` | `manager.Upgrader.UpgradeCmd` |
-| Remove | Detail view (`Enter`) → `x` | `gpk remove <pkg>` | `manager.Remover.RemoveCmd` |
-| Remove + deps | Remove modal → "package + orphaned deps" mode | `gpk remove <pkg> --with-deps` | `manager.DeepRemover.RemoveCmdWithDeps` |
-
-So the `Inst` / `Up` / `Rm` / `Deep` columns in the matrix describe **both modes** at once. If a manager has `─` in the `Rm` column, neither `x` in the TUI nor `gpk remove` from the shell works for it.
-
-**The `+y` columns are the one place TUI and headless differ.** They report whether the manager exposes a non-interactive variant (`pacman --noconfirm`, `apt -y`, etc.). The TUI doesn't use these — its modal owns confirmation, and the password field captures sudo input via `-S`. The headless `--yes` flag uses the `*Yes` interfaces when available; for managers without them, `--yes` is a safe no-op because either (a) the interactive command already includes its own non-interactive flag, or (b) the manager doesn't prompt by default. The next section unpacks this.
+**Note on `--yes`:** the headless `--yes` flag works correctly for **all 36 manager-capable tools** even though only 5 implement the explicit `NonInteractive*` interfaces. The other 31 either don't prompt by default (brew, cargo, npm, etc.) or already include their non-interactive flag in the regular command (apt has `-y` baked in, winget has `--disable-interactivity`, etc.). The 5 with explicit `*Yes` variants are the ones whose standard command does prompt: **pacman, aur, apt, dnf, chocolatey**.
 
 ## Capability matrix
 
-| Manager | Platform | Inst | Inst+y | Up | Up+y | Rm | Rm+y | Deep | Deep+y |
-|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| **pacman** | Arch Linux | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **aur** | Arch Linux | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ─ |
-| **apt** | Debian / Ubuntu | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **dnf** | Fedora / RHEL | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **chocolatey** | Windows | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ─ |
-| **brew** | macOS / Linux | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **brew-cask** | macOS | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **snap** | Linux | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **flatpak** | Linux | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **apk** | Alpine | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **xbps** | Void Linux | ✓ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ |
-| **portage** | Gentoo | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **guix** | GNU Guix | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **nix** | NixOS / cross | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **macports** | macOS | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **pkgsrc** | NetBSD / cross | ─ | ─ | ─ | ─ | ✓ | ─ | ─ | ─ |
-| **pkg** | FreeBSD | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **mas** | macOS | ✓ | ─ | ✓ | ─ | ─ | ─ | ─ | ─ |
-| **winget** | Windows | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **scoop** | Windows | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **windows-updates** | Windows | ─ | ─ | ─ | ─ | ─ | ─ | ─ | ─ |
-| **powershell** | Cross | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **nuget** | Cross | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **pip** | Cross (Python) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **pipx** | Cross (Python) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **uv** | Cross (Python) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **conda** | Cross | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **npm** | Cross (Node) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **pnpm** | Cross (Node) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **bun** | Cross (Node) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **cargo** | Cross (Rust) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **go** | Cross (Go) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **gem** | Cross (Ruby) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **opam** | Cross (OCaml) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **luarocks** | Cross (Lua) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **composer** | Cross (PHP) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
-| **maven** | Cross (Java) | ─ | ─ | ✓ | ─ | ─ | ─ | ─ | ─ |
+How to read this table: each `✓` means the manager implements the matching Go interface. `─` means it doesn't, and `gpk` either falls back gracefully (interactive command for `+y`, less rich output for read interfaces) or returns "not supported" with a clear error.
 
-## How `--yes` works in practice
+Column legend:
+- **avail** — does the binary respond on this system right now? (always `no` on systems where the manager doesn't exist)
+- **Scan** — `Manager.Scan` (list installed packages). Universal.
+- **Desc** — `Describer.Describe` (per-package descriptions for `gpk info`, list-row hints)
+- **Deps** — `DependencyLister.ListDependencies` (`gpk info`'s dependency tree, TUI's `d` overlay)
+- **Updates** — `UpdateChecker.CheckUpdates` (powers `gpk outdated`, the `↑` indicator)
+- **Search** — `Searcher.Search` (lets `gpk install <pkg>` resolve which manager has the package; also the TUI's `i` overlay)
+- **Inst / Up / Rm / Deep** — `Installer.InstallCmd` / `Upgrader.UpgradeCmd` / `Remover.RemoveCmd` / `DeepRemover.RemoveCmdWithDeps`
+- **+y** variants — `NonInteractive*` siblings used by `gpk --yes`
 
-The Inst+y / Up+y / Rm+y columns measure whether a manager has a *dedicated* non-interactive variant. But headless `--yes` works correctly for almost every manager regardless, because either:
+| Manager | Platform | avail | Scan | Desc | Deps | Updates | Search | Inst | Inst+y | Up | Up+y | Rm | Rm+y | Deep | Deep+y |
+|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| **pacman** | Arch | YES | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **aur** | Arch (via yay) | YES | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ─ |
+| **apt** | Debian / Ubuntu | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **dnf** | Fedora / RHEL | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **brew** | macOS / Linux | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **brew-cask** | macOS | no | ✓ | ✓ | ─ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **snap** | Linux | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **flatpak** | Linux | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **apk** | Alpine | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **xbps** | Void Linux | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ |
+| **portage** | Gentoo | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **guix** | GNU Guix | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **nix** | NixOS / cross | no | ✓ | ✓ | ✓ | ─ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **macports** | macOS | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **pkgsrc** | NetBSD | no | ✓ | ✓ | ✓ | ─ | ─ | ─ | ─ | ─ | ─ | ✓ | ─ | ─ | ─ |
+| **pkg** | FreeBSD | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **mas** | macOS | no | ✓ | ✓ | ─ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ─ | ─ | ─ | ─ |
+| **winget** | Windows | no | ✓ | ✓ | ─ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **chocolatey** | Windows | no | ✓ | ✓ | ─ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ─ |
+| **scoop** | Windows | no | ✓ | ✓ | ─ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **nuget** | Windows / cross | no | ✓ | ─ | ─ | ─ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **powershell** | Windows / cross | no | ✓ | ✓ | ─ | ─ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **windows-updates** | Windows | no | ✓ | ─ | ─ | ─ | ─ | ─ | ─ | ─ | ─ | ─ | ─ | ─ | ─ |
+| **pip** | Cross (Python) | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **pipx** | Cross (Python) | no | ✓ | ✓ | ─ | ─ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **uv** | Cross (Python) | YES | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **conda** | Cross | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **cargo** | Cross (Rust) | YES | ✓ | ✓ | ─ | ─ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **go** | Cross (Go) | no | ✓ | ✓ | ─ | ─ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **npm** | Cross (Node) | YES | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **pnpm** | Cross (Node) | no | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **bun** | Cross (Node) | no | ✓ | ✓ | ─ | ─ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **gem** | Cross (Ruby) | YES | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **opam** | Cross (OCaml) | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **luarocks** | Cross (Lua) | YES | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **composer** | Cross (PHP) | no | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **maven** | Cross (Java) | no | ✓ | ─ | ─ | ✓ | ─ | ─ | ─ | ✓ | ─ | ─ | ─ | ─ | ─ |
 
-1. **The interactive command already includes a `-y` / `--yes` / equivalent flag.** apt, dnf, pip, flatpak, winget, etc. ship with the non-interactive flag baked into their interactive form, because those tools assume "if you're calling me programmatically, you don't want prompts." `--yes` on these is functionally a no-op — gpk's own y/N prompt is skipped, and the manager wasn't going to prompt anyway.
-2. **The manager doesn't prompt to begin with.** brew, cargo, npm, go, pip uninstall (when given a package), pnpm, bun, gem, opam, composer, luarocks, mas, scoop, nuget — none of these ask "Proceed? [Y/n]" by default. `--yes` is a no-op for the manager's part.
-3. **The manager prompts AND has no flag to skip.** This is the case Inst+y was added for. The five managers that genuinely needed an explicit `*Yes` variant: **pacman, aur, apt, dnf, chocolatey**. All five are wired.
+## Read-side notes
 
-So while only 5 managers show `✓` in the `+y` columns, **all 36 manager-capable tools work non-interactively under `--yes`**. The two exceptions (`pkgsrc`'s install, `mas`'s remove, `maven`'s install/remove) aren't a `--yes` problem — those operations aren't exposed by the underlying tool at all.
+**Scan is universal.** Every manager `gpk` knows about lists installed packages, so `gpk list` and the TUI always work. Even `windows-updates` and `maven` — which have no install/remove semantics — implement `Scan` (windows-updates returns pending Windows updates; maven returns artifacts cached in `~/.m2/repository`).
+
+**`Desc` (`Describer`)** — when missing, `gpk info` and the TUI's detail view still show name/version/source/size, just without a description string. Missing: `nuget`, `windows-updates`, `maven`.
+
+**`Deps` (`DependencyLister`)** — when missing, `gpk info` and the TUI's `d` overlay show "(no dependency info)". This is most useful for system managers (pacman, apt, dnf, brew); cross-platform language managers like `cargo`, `go`, `bun`, `uv`, etc. often don't expose deps in a useful single-package way.
+
+**`Updates` (`UpdateChecker`)** — when missing, `gpk outdated` skips that manager silently, and the TUI's `↑` indicator never lights up for its packages. Notably missing: `pipx`, `cargo`, `go`, `bun`, `nix`, `nuget`, `powershell`, `pkgsrc`. Reason varies — most language toolchains don't ship a "what's outdated" subcommand.
+
+**`Search` (`Searcher`)** — needed for `gpk install <pkg>` to resolve which manager has the package when `--manager` isn't passed. When missing, you must pass `--manager` explicitly (`gpk install foo --manager npm`). Missing managers default to "requires `--manager`": `pipx`, `go`, `bun`, `pnpm`, `nix`, `pkgsrc`, `nuget`, `powershell`, `windows-updates`, `maven`, `uv`.
+
+## Write-side notes
+
+**`Inst` / `Up` / `Rm` are nearly universal.** Of the 37 managers, the only ones missing write operations are:
+- `pkgsrc`: install/upgrade not exposed (NetBSD's pkgsrc is bootstrap-driven from source). Remove via `pkg_delete` works.
+- `mas`: remove not exposed (Apple's Mac App Store CLI doesn't allow uninstall).
+- `maven`: only upgrade is meaningful (`mvn dependency:resolve -U`); Maven's local cache isn't a user-managed package set.
+- `windows-updates`: pure status reader. Triggering installs is owned by the Settings app.
+
+**`Deep` (`DeepRemover`) is rare.** Only 4 managers: pacman, apt, dnf, xbps. These tools have a dedicated "remove this package AND its orphaned dependencies" command (`pacman -Rns`, `apt-get autoremove`, `dnf autoremove`, `xbps-remove -R`). Others can be approximated by `gpk remove pkg && gpk autoremove`, but autoremove isn't exposed as a separate gpk command yet.
+
+**Non-interactive (`+y`) coverage is intentional.** Only the 5 managers whose default command prompts the user for confirmation have `*Yes` variants: pacman, aur, apt, dnf, chocolatey. Every other manager either doesn't prompt at all or bakes the non-interactive flag into its standard command — so `--yes` from gpk gives the user a noop on those (the underlying call was already silent) without needing a separate code path.
+
+## TUI vs headless
+
+Both modes call **the same** Go interfaces. There is no manager that works in the TUI but not headless, or vice versa. The only differences are surface:
+
+- **Confirmation**: the TUI shows a modal with a password field (uses sudo `-S` to pipe). Headless prompts on the terminal and uses sudo's normal `tty` prompt; `--yes` skips entirely.
+- **Batch operations**: the TUI's `m` multi-select with `Space` lets you select packages across managers and run a single command per privilege group. Headless takes multiple package names per command (`gpk install a b c`) but doesn't yet have a `gpk upgrade --all`.
+- **Snapshots / diff / export**: Phase 1 TUI-only. A future phase may add headless equivalents.
 
 ## Sample constructed commands
 
-Below are the exact `*exec.Cmd` arguments `gpk` builds for a hypothetical package `DUMMY`. Generated by `TestManagerCommandSamples`; rerun the test to refresh if you change a manager's command construction.
+The exact `*exec.Cmd` arguments `gpk` builds for a hypothetical package `DUMMY`. Generated by `TestManagerCommandSamples`; rerun the test to refresh.
 
 ### Arch Linux
 
@@ -118,7 +146,7 @@ Below are the exact `*exec.Cmd` arguments `gpk` builds for a hypothetical packag
   remove --yes:   sudo pacman -R --noconfirm DUMMY
 ```
 
-AUR remove delegates to pacman because `yay -R` is just a passthrough to pacman; using pacman directly is more honest.
+AUR remove delegates to pacman because `yay -R` is a passthrough; using pacman directly is more honest.
 
 ### Debian / Ubuntu / Fedora
 
@@ -136,9 +164,9 @@ AUR remove delegates to pacman because `yay -R` is just a passthrough to pacman;
   remove deps:    sudo dnf autoremove -y DUMMY
 ```
 
-The `-y` is baked into the interactive form; `--yes` produces an identical command (the explicit `+y` variants exist for symmetry / safety against future changes).
+`-y` is baked into the interactive form on these — `--yes` produces an identical command.
 
-### macOS / Linux
+### macOS
 
 ```
 === brew ===
@@ -162,8 +190,6 @@ The `-y` is baked into the interactive form; `--yes` produces an identical comma
   remove:         sudo port uninstall DUMMY
 ```
 
-brew doesn't prompt — `--yes` is a no-op. `mas` (Mac App Store) can't uninstall from CLI; Apple restriction.
-
 ### Windows
 
 ```
@@ -172,20 +198,15 @@ brew doesn't prompt — `--yes` is a no-op. `mas` (Mac App Store) can't uninstal
   upgrade:        winget upgrade --id DUMMY --exact --accept-source-agreements --accept-package-agreements --disable-interactivity
   remove:         winget uninstall --id DUMMY --exact --disable-interactivity
 
-=== scoop ===
-  install:        scoop install DUMMY
-  upgrade:        scoop update DUMMY
-  remove:         scoop uninstall DUMMY
-
 === chocolatey ===
   install:        choco install DUMMY --yes
   upgrade:        choco upgrade DUMMY --yes
   remove:         choco uninstall DUMMY --yes
 
-=== nuget ===
-  install:        nuget install DUMMY
-  upgrade:        nuget update DUMMY
-  remove:         (filesystem delete in ~/.nuget/packages/)
+=== scoop ===
+  install:        scoop install DUMMY
+  upgrade:        scoop update DUMMY
+  remove:         scoop uninstall DUMMY
 
 === powershell ===
   install:        Install-Module -Name DUMMY -Force
@@ -198,7 +219,55 @@ brew doesn't prompt — `--yes` is a no-op. `mas` (Mac App Store) can't uninstal
   remove:         (not supported)
 ```
 
-`winget` builds in all four "yes" flags already. `windows-updates` is a status reader — write operations are owned by the Settings app.
+### Linux distro-specifics
+
+```
+=== snap ===
+  install:        sudo snap install DUMMY
+  upgrade:        sudo snap refresh DUMMY
+  remove:         sudo snap remove DUMMY
+
+=== flatpak ===
+  install:        flatpak install -y DUMMY
+  upgrade:        flatpak update -y DUMMY
+  remove:         flatpak uninstall -y DUMMY
+
+=== apk ===
+  install:        sudo apk add DUMMY
+  upgrade:        sudo apk add --upgrade DUMMY
+  remove:         sudo apk del DUMMY
+
+=== xbps ===
+  install:        sudo xbps-install -y DUMMY
+  upgrade:        sudo xbps-install -y DUMMY
+  remove:         sudo xbps-remove -y DUMMY
+  remove deps:    sudo xbps-remove -Ry DUMMY
+
+=== portage ===
+  install:        sudo emerge DUMMY
+  upgrade:        sudo emerge --update DUMMY
+  remove:         sudo emerge --unmerge DUMMY
+
+=== guix ===
+  install:        guix install DUMMY
+  upgrade:        guix upgrade DUMMY
+  remove:         guix remove DUMMY
+
+=== nix ===
+  install:        nix profile install nixpkgs#DUMMY
+  upgrade:        nix profile upgrade DUMMY
+  remove:         nix profile remove DUMMY
+
+=== pkg ===
+  install:        sudo pkg install -y DUMMY
+  upgrade:        sudo pkg upgrade -y DUMMY
+  remove:         sudo pkg delete -y DUMMY
+
+=== pkgsrc ===
+  install:        (not supported; pkgsrc is bootstrap-driven)
+  upgrade:        (not supported)
+  remove:         sudo pkg_delete DUMMY
+```
 
 ### Cross-platform language tools
 
@@ -272,70 +341,26 @@ brew doesn't prompt — `--yes` is a no-op. `mas` (Mac App Store) can't uninstal
   install:        (not supported)
   upgrade:        mvn dependency:resolve -U
   remove:         (not supported)
+
+=== nuget ===
+  install:        nuget install DUMMY
+  upgrade:        nuget update DUMMY
+  remove:         (filesystem delete in ~/.nuget/packages/)
 ```
 
 `go remove` is the only filesystem-level operation in the matrix — `go` itself has no uninstall command, so gpk runs `rm $GOPATH/bin/<name>`. Safe because the file was created by `go install` in the first place.
 
-### Linux distro-specifics
-
-```
-=== snap ===
-  install:        sudo snap install DUMMY
-  upgrade:        sudo snap refresh DUMMY
-  remove:         sudo snap remove DUMMY
-
-=== flatpak ===
-  install:        flatpak install -y DUMMY
-  upgrade:        flatpak update -y DUMMY
-  remove:         flatpak uninstall -y DUMMY
-
-=== apk ===
-  install:        sudo apk add DUMMY
-  upgrade:        sudo apk add --upgrade DUMMY
-  remove:         sudo apk del DUMMY
-
-=== xbps ===
-  install:        sudo xbps-install -y DUMMY
-  upgrade:        sudo xbps-install -y DUMMY
-  remove:         sudo xbps-remove -y DUMMY
-  remove deps:    sudo xbps-remove -Ry DUMMY
-
-=== portage ===
-  install:        sudo emerge DUMMY
-  upgrade:        sudo emerge --update DUMMY
-  remove:         sudo emerge --unmerge DUMMY
-
-=== guix ===
-  install:        guix install DUMMY
-  upgrade:        guix upgrade DUMMY
-  remove:         guix remove DUMMY
-
-=== nix ===
-  install:        nix profile install nixpkgs#DUMMY
-  upgrade:        nix profile upgrade DUMMY
-  remove:         nix profile remove DUMMY
-
-=== pkg ===
-  install:        sudo pkg install -y DUMMY
-  upgrade:        sudo pkg upgrade -y DUMMY
-  remove:         sudo pkg delete -y DUMMY
-
-=== pkgsrc ===
-  install:        (not supported; pkgsrc is bootstrap-driven)
-  upgrade:        (not supported)
-  remove:         sudo pkg_delete DUMMY
-```
-
 ## Deliberate gaps
 
-Four managers have intentionally-missing write capabilities. They aren't bugs in gpk:
+Five spots where a manager intentionally doesn't implement an interface. These aren't gpk bugs:
 
 | Manager | Missing | Why |
 |---|---|---|
-| `pkgsrc` | Install, Upgrade | NetBSD's pkgsrc is bootstrap-driven; there's no single-command install. Use `make install` from the source tree. |
-| `mas` | Remove | Mac App Store CLI deliberately doesn't expose uninstall (Apple restriction). Use the GUI Launchpad / Finder. |
-| `maven` | Install, Remove | Maven's local cache (`~/.m2/repository`) is build-output, not a user-managed package set. There's no "uninstall" concept. |
-| `windows-updates` | All | This is a status-only manager — counts pending Windows updates. Triggering the install is owned by the Settings app or `UsoClient`. |
+| `pkgsrc` | Install, Upgrade, Search, Updates | NetBSD's pkgsrc is bootstrap-driven; there's no single-command install. Use `make install` from the source tree. |
+| `mas` | Remove, Deps | Mac App Store CLI deliberately doesn't expose uninstall (Apple restriction). Apps that come from `mas` don't have a meaningful dependency graph. |
+| `maven` | Install, Remove, Search, Deps, Desc | Maven's local cache (`~/.m2/repository`) is build-output, not a user-managed package set. There's no install/remove concept; the only write op is "refresh the cache" via `mvn dependency:resolve -U`. |
+| `windows-updates` | Almost everything | Status-only manager — counts pending Windows updates. Triggering the install is owned by the Settings app or `UsoClient`. |
+| `nuget` | Desc, Deps, Updates, Search | NuGet's surface here is the global package cache. Per-package introspection beyond install/upgrade/remove is package-source-dependent and not surfaced by the `nuget` CLI in a portable way. |
 
 ## Verifying locally
 
@@ -352,17 +377,36 @@ For a single manager's commands:
 go test ./tests/integration/... -run 'TestManagerCommandSamples/pacman$' -v
 ```
 
-## Adding non-interactive support to a new manager
+## Adding support to a new manager
 
-If a manager's interactive command prompts and the underlying tool has a flag to skip the prompt, implement the matching `NonInteractive*` interface from `internal/manager/noninteractive.go`. Example for a fictional `xyz` manager:
+A new manager is one Go file in `internal/manager/`. The minimum is `Manager.Scan`; everything else is opt-in:
 
 ```go
-// internal/manager/xyz.go
-func (x *XYZ) InstallCmdYes(name string) *exec.Cmd {
-    return exec.Command("xyz", "install", "--no-confirm", name)
-}
-func (x *XYZ) UpgradeCmdYes(name string) *exec.Cmd { ... }
-func (x *XYZ) RemoveCmdYes(name string) *exec.Cmd { ... }
+package manager
+
+import "os/exec"
+
+type Mytool struct{}
+
+func (m *Mytool) Name() model.Source { return model.SourceMytool }
+func (m *Mytool) Available() bool    { return commandExists("mytool") }
+func (m *Mytool) Scan() ([]model.Package, error) { /* parse `mytool list` */ }
+
+// Opt-in capabilities — add the methods you want gpk to support:
+func (m *Mytool) Describe(pkgs []model.Package) map[string]string { ... }
+func (m *Mytool) ListDependencies(pkgs []model.Package) map[string][]string { ... }
+func (m *Mytool) CheckUpdates(pkgs []model.Package) map[string]string { ... }
+func (m *Mytool) Search(query string) ([]model.Package, error) { ... }
+func (m *Mytool) InstallCmd(name string) *exec.Cmd { ... }
+func (m *Mytool) UpgradeCmd(name string) *exec.Cmd { ... }
+func (m *Mytool) RemoveCmd(name string) *exec.Cmd { ... }
+
+// And if the tool prompts and has a flag to skip:
+func (m *Mytool) InstallCmdYes(name string) *exec.Cmd { ... }
+func (m *Mytool) UpgradeCmdYes(name string) *exec.Cmd { ... }
+func (m *Mytool) RemoveCmdYes(name string) *exec.Cmd { ... }
 ```
 
-`gpk` automatically picks up the `*Yes` variant when the user passes `--yes`. If the tool already runs non-interactively without a flag (most cross-platform language managers), skip this — `gpk`'s `--yes` is already a no-op for those.
+Then register: add `&Mytool{}` to `manager.All()` in `manager.go`. The audit test will pick it up automatically on next run.
+
+Full guide in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,353 @@
+# Manager Compatibility
+
+Reference for which package managers support which headless write operations (`gpk install` / `remove` / `upgrade`), and what command each one constructs. This is the source of truth for `gpk`'s cross-OS coverage claims.
+
+> **Regenerating this doc:** the matrix is derived from the manager interfaces in `internal/manager/`. To re-run the audit and see fresh output:
+> ```bash
+> go test ./tests/integration/... -run TestManagerCapabilityMatrix -v
+> go test ./tests/integration/... -run TestManagerCommandSamples -v
+> ```
+
+## How to read the matrix
+
+Each column reports whether the manager implements the matching Go interface in `internal/manager/`:
+
+| Column | Interface | What it controls |
+|---|---|---|
+| `Inst` | `Installer` | `gpk install <pkg>` |
+| `Inst+y` | `NonInteractiveInstaller` | `gpk install <pkg> --yes` skips the manager's own prompt |
+| `Up` | `Upgrader` | `gpk upgrade <pkg>` |
+| `Up+y` | `NonInteractiveUpgrader` | `gpk upgrade <pkg> --yes` |
+| `Rm` | `Remover` | `gpk remove <pkg>` |
+| `Rm+y` | `NonInteractiveRemover` | `gpk remove <pkg> --yes` |
+| `Deep` | `DeepRemover` | `gpk remove <pkg> --with-deps` |
+| `Deep+y` | `NonInteractiveDeepRemover` | `gpk remove <pkg> --with-deps --yes` |
+
+A `✓` means the interface is implemented; `─` means it isn't, and `gpk` falls back gracefully (interactive command for `+y`, error message for unsupported ops).
+
+## Capability matrix
+
+| Manager | Platform | Inst | Inst+y | Up | Up+y | Rm | Rm+y | Deep | Deep+y |
+|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| **pacman** | Arch Linux | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **aur** | Arch Linux | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ─ |
+| **apt** | Debian / Ubuntu | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **dnf** | Fedora / RHEL | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **chocolatey** | Windows | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ─ | ─ |
+| **brew** | macOS / Linux | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **brew-cask** | macOS | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **snap** | Linux | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **flatpak** | Linux | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **apk** | Alpine | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **xbps** | Void Linux | ✓ | ─ | ✓ | ─ | ✓ | ─ | ✓ | ─ |
+| **portage** | Gentoo | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **guix** | GNU Guix | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **nix** | NixOS / cross | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **macports** | macOS | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **pkgsrc** | NetBSD / cross | ─ | ─ | ─ | ─ | ✓ | ─ | ─ | ─ |
+| **pkg** | FreeBSD | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **mas** | macOS | ✓ | ─ | ✓ | ─ | ─ | ─ | ─ | ─ |
+| **winget** | Windows | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **scoop** | Windows | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **windows-updates** | Windows | ─ | ─ | ─ | ─ | ─ | ─ | ─ | ─ |
+| **powershell** | Cross | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **nuget** | Cross | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **pip** | Cross (Python) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **pipx** | Cross (Python) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **uv** | Cross (Python) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **conda** | Cross | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **npm** | Cross (Node) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **pnpm** | Cross (Node) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **bun** | Cross (Node) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **cargo** | Cross (Rust) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **go** | Cross (Go) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **gem** | Cross (Ruby) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **opam** | Cross (OCaml) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **luarocks** | Cross (Lua) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **composer** | Cross (PHP) | ✓ | ─ | ✓ | ─ | ✓ | ─ | ─ | ─ |
+| **maven** | Cross (Java) | ─ | ─ | ✓ | ─ | ─ | ─ | ─ | ─ |
+
+## How `--yes` works in practice
+
+The Inst+y / Up+y / Rm+y columns measure whether a manager has a *dedicated* non-interactive variant. But headless `--yes` works correctly for almost every manager regardless, because either:
+
+1. **The interactive command already includes a `-y` / `--yes` / equivalent flag.** apt, dnf, pip, flatpak, winget, etc. ship with the non-interactive flag baked into their interactive form, because those tools assume "if you're calling me programmatically, you don't want prompts." `--yes` on these is functionally a no-op — gpk's own y/N prompt is skipped, and the manager wasn't going to prompt anyway.
+2. **The manager doesn't prompt to begin with.** brew, cargo, npm, go, pip uninstall (when given a package), pnpm, bun, gem, opam, composer, luarocks, mas, scoop, nuget — none of these ask "Proceed? [Y/n]" by default. `--yes` is a no-op for the manager's part.
+3. **The manager prompts AND has no flag to skip.** This is the case Inst+y was added for. The five managers that genuinely needed an explicit `*Yes` variant: **pacman, aur, apt, dnf, chocolatey**. All five are wired.
+
+So while only 5 managers show `✓` in the `+y` columns, **all 36 manager-capable tools work non-interactively under `--yes`**. The two exceptions (`pkgsrc`'s install, `mas`'s remove, `maven`'s install/remove) aren't a `--yes` problem — those operations aren't exposed by the underlying tool at all.
+
+## Sample constructed commands
+
+Below are the exact `*exec.Cmd` arguments `gpk` builds for a hypothetical package `DUMMY`. Generated by `TestManagerCommandSamples`; rerun the test to refresh if you change a manager's command construction.
+
+### Arch Linux
+
+```
+=== pacman ===
+  install:        sudo pacman -S DUMMY
+  install --yes:  sudo pacman -S --noconfirm DUMMY
+  upgrade:        sudo pacman -S DUMMY
+  upgrade --yes:  sudo pacman -S --noconfirm DUMMY
+  remove:         sudo pacman -R DUMMY
+  remove --yes:   sudo pacman -R --noconfirm DUMMY
+  remove deps:    sudo pacman -Rns DUMMY
+  remove deps -y: sudo pacman -Rns --noconfirm DUMMY
+
+=== aur ===
+  install:        yay -S DUMMY
+  install --yes:  yay -S --noconfirm DUMMY
+  upgrade:        yay -S DUMMY
+  upgrade --yes:  yay -S --noconfirm DUMMY
+  remove:         sudo pacman -R DUMMY
+  remove --yes:   sudo pacman -R --noconfirm DUMMY
+```
+
+AUR remove delegates to pacman because `yay -R` is just a passthrough to pacman; using pacman directly is more honest.
+
+### Debian / Ubuntu / Fedora
+
+```
+=== apt ===
+  install:        sudo apt-get install -y DUMMY
+  upgrade:        sudo apt-get install --only-upgrade -y DUMMY
+  remove:         sudo apt-get remove -y DUMMY
+  remove deps:    sudo apt-get autoremove -y DUMMY
+
+=== dnf ===
+  install:        sudo dnf install -y DUMMY
+  upgrade:        sudo dnf upgrade -y DUMMY
+  remove:         sudo dnf remove -y DUMMY
+  remove deps:    sudo dnf autoremove -y DUMMY
+```
+
+The `-y` is baked into the interactive form; `--yes` produces an identical command (the explicit `+y` variants exist for symmetry / safety against future changes).
+
+### macOS / Linux
+
+```
+=== brew ===
+  install:        brew install DUMMY
+  upgrade:        brew upgrade DUMMY
+  remove:         brew uninstall DUMMY
+
+=== brew-cask ===
+  install:        brew install --cask DUMMY
+  upgrade:        brew upgrade --cask DUMMY
+  remove:         brew uninstall --cask DUMMY
+
+=== mas ===
+  install:        mas install DUMMY
+  upgrade:        mas upgrade
+  remove:         (not supported)
+
+=== macports ===
+  install:        sudo port install DUMMY
+  upgrade:        sudo port upgrade DUMMY
+  remove:         sudo port uninstall DUMMY
+```
+
+brew doesn't prompt — `--yes` is a no-op. `mas` (Mac App Store) can't uninstall from CLI; Apple restriction.
+
+### Windows
+
+```
+=== winget ===
+  install:        winget install --id DUMMY --exact --accept-source-agreements --accept-package-agreements --disable-interactivity
+  upgrade:        winget upgrade --id DUMMY --exact --accept-source-agreements --accept-package-agreements --disable-interactivity
+  remove:         winget uninstall --id DUMMY --exact --disable-interactivity
+
+=== scoop ===
+  install:        scoop install DUMMY
+  upgrade:        scoop update DUMMY
+  remove:         scoop uninstall DUMMY
+
+=== chocolatey ===
+  install:        choco install DUMMY --yes
+  upgrade:        choco upgrade DUMMY --yes
+  remove:         choco uninstall DUMMY --yes
+
+=== nuget ===
+  install:        nuget install DUMMY
+  upgrade:        nuget update DUMMY
+  remove:         (filesystem delete in ~/.nuget/packages/)
+
+=== powershell ===
+  install:        Install-Module -Name DUMMY -Force
+  upgrade:        Update-Module -Name DUMMY -Force
+  remove:         Uninstall-Module -Name DUMMY -Force
+
+=== windows-updates ===
+  install:        (not supported)
+  upgrade:        (not supported)
+  remove:         (not supported)
+```
+
+`winget` builds in all four "yes" flags already. `windows-updates` is a status reader — write operations are owned by the Settings app.
+
+### Cross-platform language tools
+
+```
+=== pip ===
+  install:        pip install DUMMY
+  upgrade:        pip install --upgrade DUMMY
+  remove:         pip uninstall -y DUMMY
+
+=== pipx ===
+  install:        pipx install DUMMY
+  upgrade:        pipx upgrade DUMMY
+  remove:         pipx uninstall DUMMY
+
+=== uv ===
+  install:        uv tool install DUMMY
+  upgrade:        uv tool upgrade DUMMY
+  remove:         uv tool uninstall DUMMY
+
+=== conda ===
+  install:        conda install -y DUMMY
+  upgrade:        conda update -y DUMMY
+  remove:         conda remove -y DUMMY
+
+=== cargo ===
+  install:        cargo install DUMMY
+  upgrade:        cargo install DUMMY
+  remove:         cargo uninstall DUMMY
+
+=== go ===
+  install:        go install DUMMY@latest
+  upgrade:        go install DUMMY@latest
+  remove:         rm ~/go/bin/DUMMY
+
+=== npm ===
+  install:        npm install -g DUMMY
+  upgrade:        npm install -g DUMMY@latest
+  remove:         npm uninstall -g DUMMY
+
+=== pnpm ===
+  install:        pnpm add -g DUMMY
+  upgrade:        pnpm update -g DUMMY
+  remove:         pnpm remove -g DUMMY
+
+=== bun ===
+  install:        bun add -g DUMMY
+  upgrade:        bun update -g DUMMY
+  remove:         bun remove -g DUMMY
+
+=== gem ===
+  install:        gem install DUMMY
+  upgrade:        gem update DUMMY
+  remove:         gem uninstall DUMMY
+
+=== opam ===
+  install:        opam install -y DUMMY
+  upgrade:        opam upgrade -y DUMMY
+  remove:         opam remove -y DUMMY
+
+=== luarocks ===
+  install:        luarocks install DUMMY
+  upgrade:        luarocks install DUMMY
+  remove:         luarocks remove DUMMY
+
+=== composer ===
+  install:        composer global require DUMMY
+  upgrade:        composer global update DUMMY
+  remove:         composer global remove DUMMY
+
+=== maven ===
+  install:        (not supported)
+  upgrade:        mvn dependency:resolve -U
+  remove:         (not supported)
+```
+
+`go remove` is the only filesystem-level operation in the matrix — `go` itself has no uninstall command, so gpk runs `rm $GOPATH/bin/<name>`. Safe because the file was created by `go install` in the first place.
+
+### Linux distro-specifics
+
+```
+=== snap ===
+  install:        sudo snap install DUMMY
+  upgrade:        sudo snap refresh DUMMY
+  remove:         sudo snap remove DUMMY
+
+=== flatpak ===
+  install:        flatpak install -y DUMMY
+  upgrade:        flatpak update -y DUMMY
+  remove:         flatpak uninstall -y DUMMY
+
+=== apk ===
+  install:        sudo apk add DUMMY
+  upgrade:        sudo apk add --upgrade DUMMY
+  remove:         sudo apk del DUMMY
+
+=== xbps ===
+  install:        sudo xbps-install -y DUMMY
+  upgrade:        sudo xbps-install -y DUMMY
+  remove:         sudo xbps-remove -y DUMMY
+  remove deps:    sudo xbps-remove -Ry DUMMY
+
+=== portage ===
+  install:        sudo emerge DUMMY
+  upgrade:        sudo emerge --update DUMMY
+  remove:         sudo emerge --unmerge DUMMY
+
+=== guix ===
+  install:        guix install DUMMY
+  upgrade:        guix upgrade DUMMY
+  remove:         guix remove DUMMY
+
+=== nix ===
+  install:        nix profile install nixpkgs#DUMMY
+  upgrade:        nix profile upgrade DUMMY
+  remove:         nix profile remove DUMMY
+
+=== pkg ===
+  install:        sudo pkg install -y DUMMY
+  upgrade:        sudo pkg upgrade -y DUMMY
+  remove:         sudo pkg delete -y DUMMY
+
+=== pkgsrc ===
+  install:        (not supported; pkgsrc is bootstrap-driven)
+  upgrade:        (not supported)
+  remove:         sudo pkg_delete DUMMY
+```
+
+## Deliberate gaps
+
+Four managers have intentionally-missing write capabilities. They aren't bugs in gpk:
+
+| Manager | Missing | Why |
+|---|---|---|
+| `pkgsrc` | Install, Upgrade | NetBSD's pkgsrc is bootstrap-driven; there's no single-command install. Use `make install` from the source tree. |
+| `mas` | Remove | Mac App Store CLI deliberately doesn't expose uninstall (Apple restriction). Use the GUI Launchpad / Finder. |
+| `maven` | Install, Remove | Maven's local cache (`~/.m2/repository`) is build-output, not a user-managed package set. There's no "uninstall" concept. |
+| `windows-updates` | All | This is a status-only manager — counts pending Windows updates. Triggering the install is owned by the Settings app or `UsoClient`. |
+
+## Verifying locally
+
+Reproduce the matrix and per-manager commands on your machine:
+
+```bash
+go test ./tests/integration/... -run TestManagerCapabilityMatrix -v
+go test ./tests/integration/... -run TestManagerCommandSamples -v
+```
+
+For a single manager's commands:
+
+```bash
+go test ./tests/integration/... -run 'TestManagerCommandSamples/pacman$' -v
+```
+
+## Adding non-interactive support to a new manager
+
+If a manager's interactive command prompts and the underlying tool has a flag to skip the prompt, implement the matching `NonInteractive*` interface from `internal/manager/noninteractive.go`. Example for a fictional `xyz` manager:
+
+```go
+// internal/manager/xyz.go
+func (x *XYZ) InstallCmdYes(name string) *exec.Cmd {
+    return exec.Command("xyz", "install", "--no-confirm", name)
+}
+func (x *XYZ) UpgradeCmdYes(name string) *exec.Cmd { ... }
+func (x *XYZ) RemoveCmdYes(name string) *exec.Cmd { ... }
+```
+
+`gpk` automatically picks up the `*Yes` variant when the user passes `--yes`. If the tool already runs non-interactively without a flag (most cross-platform language managers), skip this — `gpk`'s `--yes` is already a no-op for those.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -25,6 +25,21 @@ Each column reports whether the manager implements the matching Go interface in 
 
 A `✓` means the interface is implemented; `─` means it isn't, and `gpk` falls back gracefully (interactive command for `+y`, error message for unsupported ops).
 
+## TUI vs headless coverage
+
+The TUI (`gpk` with no args) and the headless commands share the **same** manager interfaces — there's no manager that the TUI supports but headless doesn't, or vice versa.
+
+| Operation | TUI surface | Headless surface | Interface both call |
+|---|---|---|---|
+| Install | Search panel (`i`) → result row → install confirmation | `gpk install <pkg>` | `manager.Installer.InstallCmd` |
+| Upgrade | Detail view (`Enter`) → `u` | `gpk upgrade <pkg>` | `manager.Upgrader.UpgradeCmd` |
+| Remove | Detail view (`Enter`) → `x` | `gpk remove <pkg>` | `manager.Remover.RemoveCmd` |
+| Remove + deps | Remove modal → "package + orphaned deps" mode | `gpk remove <pkg> --with-deps` | `manager.DeepRemover.RemoveCmdWithDeps` |
+
+So the `Inst` / `Up` / `Rm` / `Deep` columns in the matrix describe **both modes** at once. If a manager has `─` in the `Rm` column, neither `x` in the TUI nor `gpk remove` from the shell works for it.
+
+**The `+y` columns are the one place TUI and headless differ.** They report whether the manager exposes a non-interactive variant (`pacman --noconfirm`, `apt -y`, etc.). The TUI doesn't use these — its modal owns confirmation, and the password field captures sudo input via `-S`. The headless `--yes` flag uses the `*Yes` interfaces when available; for managers without them, `--yes` is a safe no-op because either (a) the interactive command already includes its own non-interactive flag, or (b) the manager doesn't prompt by default. The next section unpacks this.
+
 ## Capability matrix
 
 | Manager | Platform | Inst | Inst+y | Up | Up+y | Rm | Rm+y | Deep | Deep+y |

--- a/cmd/gpk/main.go
+++ b/cmd/gpk/main.go
@@ -32,7 +32,7 @@ func main() {
 		// cli.Dispatch handles unknown names with a clean error + ExitErr,
 		// so users typing `gpk install foo` get a real message instead of
 		// the TUI failing with a TTY error.
-		os.Exit(cli.Dispatch(os.Args[1:], manager.All(), version, os.Stdout, os.Stderr))
+		os.Exit(cli.Dispatch(os.Args[1:], manager.All(), version, os.Stdout, os.Stderr, os.Stdin))
 	}
 
 	p := tea.NewProgram(ui.NewModel(version), tea.WithAltScreen())

--- a/cmd/gpk/main.go
+++ b/cmd/gpk/main.go
@@ -63,13 +63,16 @@ Usage:
   gpk version      Show current version
   gpk --help       Show this help
 
-Headless commands (Phase 1, read-only):
+Headless commands:
   gpk list                    List installed packages across all managers
   gpk installed <pkg>...      Exit 0 if all named packages are installed (2 if not)
   gpk info <pkg>              Show details for one installed package
   gpk source-of <pkg>         Print which manager has the package
   gpk outdated                List packages with available updates
                               (--count for a number, --exit-code for CI gates)
+  gpk install <pkg>...        Install one or more packages (prompts unless --yes)
+  gpk remove <pkg>...         Remove a package (--with-deps for orphan cleanup)
+  gpk upgrade <pkg>...        Upgrade installed packages to latest
 
 Run "gpk <subcommand> --help" for per-command flags.
 

--- a/cmd/gpk/main.go
+++ b/cmd/gpk/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-isatty"
 
 	"github.com/neur0map/glazepkg/internal/cli"
 	"github.com/neur0map/glazepkg/internal/manager"
@@ -55,58 +56,96 @@ func runUpdate() {
 }
 
 func printHelp() {
-	help := `GlazePKG (gpk) — eye-candy package viewer
+	tty := isatty.IsTerminal(os.Stdout.Fd())
+	var bold, cyan, yellow, dim, reset string
+	if tty {
+		bold = "\033[1m"
+		cyan = "\033[36m"
+		yellow = "\033[33m"
+		dim = "\033[2m"
+		reset = "\033[0m"
+	}
 
-Usage:
-  gpk              Launch TUI
-  gpk update       Self-update to latest release
-  gpk version      Show current version
-  gpk --help       Show this help
+	section := func(name string) string {
+		return bold + name + reset
+	}
+	cmd := func(name string) string {
+		return cyan + name + reset
+	}
+	flagText := func(s string) string {
+		return yellow + s + reset
+	}
+	muted := func(s string) string {
+		return dim + s + reset
+	}
 
-Headless commands:
-  gpk list                    List installed packages across all managers
-  gpk installed <pkg>...      Exit 0 if all named packages are installed (2 if not)
-  gpk info <pkg>              Show details for one installed package
-  gpk source-of <pkg>         Print which manager has the package
-  gpk outdated                List packages with available updates
-                              (--count for a number, --exit-code for CI gates)
-  gpk install <pkg>...        Install one or more packages (prompts unless --yes)
-  gpk remove <pkg>...         Remove a package (--with-deps for orphan cleanup)
-  gpk upgrade <pkg>...        Upgrade installed packages to latest
+	fmt.Printf("%s · %s\n", bold+"gpk"+reset, muted("eye-candy package viewer"))
+	fmt.Println()
 
-Run "gpk <subcommand> --help" for per-command flags.
+	fmt.Println(section("USAGE"))
+	fmt.Printf("  %-22s %s\n", cmd("gpk"), "Launch the TUI")
+	fmt.Printf("  %-22s %s\n", cmd("gpk <subcommand>"), "Run a headless command")
+	fmt.Printf("  %-22s %s\n", cmd("gpk update"), "Self-update to latest release")
+	fmt.Printf("  %-22s %s\n", cmd("gpk version"), "Show current version")
+	fmt.Printf("  %-22s %s\n", cmd("gpk -h, --help"), "Show this help")
+	fmt.Println()
 
-Keybinds (TUI):
-  j/k, ↑/↓         Navigate up/down
-  g/G              Jump to top/bottom
-  Ctrl+d/u         Half page down/up
-  PgDn/PgUp        Page down/up
-  Tab/Shift+Tab    Cycle manager tabs
-  /                Fuzzy search
-  Esc              Clear search / close overlay
-  Enter            Package details
-  u (detail)       Upgrade package
-  x (detail)       Remove package
-  e (detail)       Edit description
-  r                Rescan all managers
-  s                Save snapshot
-  i                Search + install packages
-  d                Diff against last snapshot
-  e                Export packages
-  ?                Toggle help overlay
-  q                Quit
+	fmt.Printf("%s %s\n", section("HEADLESS"), muted("· read-only"))
+	fmt.Printf("  %-22s %s\n", cmd("list"), "List installed packages across all managers")
+	fmt.Printf("  %-22s %s\n", cmd("installed <pkg>..."), "Check if packages are installed (exit 0/2)")
+	fmt.Printf("  %-22s %s\n", cmd("info <pkg>"), "Show details for one installed package")
+	fmt.Printf("  %-22s %s\n", cmd("source-of <pkg>"), "Print which manager has the package")
+	fmt.Printf("  %-22s %s\n", cmd("outdated"), "List packages with available updates")
+	fmt.Println()
 
-Supported managers:
-  brew, pacman, aur, apt, dnf, snap, pip, pipx, uv,
-  cargo, go, npm, pnpm, bun, flatpak, macports, pkgsrc,
-  opam, gem, pkg, composer, mas, apk, nix, conda,
-  luarocks, xbps, portage, guix, winget, chocolatey,
-  nuget, powershell, windows-updates, scoop, maven
+	fmt.Printf("%s %s\n", section("HEADLESS"), muted("· write"))
+	fmt.Printf("  %-22s %s\n", cmd("install <pkg>..."), "Install one or more packages")
+	fmt.Printf("  %-22s %s\n", cmd("remove <pkg>..."), "Remove a package (--with-deps for orphans)")
+	fmt.Printf("  %-22s %s\n", cmd("upgrade <pkg>..."), "Upgrade installed packages to latest")
+	fmt.Println()
 
-Data:
-  Snapshots   ~/.local/share/glazepkg/snapshots/
-  Exports     ~/.local/share/glazepkg/exports/
-  Desc cache  ~/.local/share/glazepkg/cache/`
+	fmt.Println(section("COMMON FLAGS"))
+	fmt.Printf("  %s   filter manager (e.g. pacman, pacman,aur, !brew)\n", flagText("--manager M, -m"))
+	fmt.Printf("  %s              emit a JSON envelope on stdout\n", flagText("--json"))
+	fmt.Printf("  %s          bypass the scan/update cache\n", flagText("--no-cache"))
+	fmt.Printf("  %s         skip the y/N prompt for writes (also skips manager's prompt)\n", flagText("--yes, -y"))
+	fmt.Printf("  %s           print the command without running it (writes only)\n", flagText("--dry-run"))
+	fmt.Printf("  %s       suppress progress on stderr\n", flagText("--quiet, -q"))
+	fmt.Printf("  %s\n", muted("Run `gpk <subcommand> --help` for the full per-command flag list."))
+	fmt.Println()
 
-	fmt.Println(help)
+	fmt.Println(section("EXIT CODES"))
+	fmt.Printf("  %s  %s\n", yellow+"0"+reset, "success / clean / yes")
+	fmt.Printf("  %s  %s\n", yellow+"1"+reset, "error (bad flag, scan failed, IO)")
+	fmt.Printf("  %s  %s\n", yellow+"2"+reset, "meaningful 'no' (not installed, has updates, not found)")
+	fmt.Printf("  %s  %s\n", yellow+"3"+reset, "ambiguous (package available in multiple managers; use --manager)")
+	fmt.Println()
+
+	fmt.Println(section("TUI KEYBINDS"))
+	fmt.Printf("  %-18s %s\n", cmd("j/k, ↑/↓"), "Navigate up/down")
+	fmt.Printf("  %-18s %s\n", cmd("g/G"), "Jump to top/bottom")
+	fmt.Printf("  %-18s %s\n", cmd("Ctrl+d/u"), "Half page down/up")
+	fmt.Printf("  %-18s %s\n", cmd("Tab/Shift+Tab"), "Cycle manager tabs")
+	fmt.Printf("  %-18s %s\n", cmd("/"), "Fuzzy search")
+	fmt.Printf("  %-18s %s\n", cmd("Enter"), "Package details")
+	fmt.Printf("  %-18s %s\n", cmd("u / x (detail)"), "Upgrade / remove the focused package")
+	fmt.Printf("  %-18s %s\n", cmd("i"), "Search + install across managers")
+	fmt.Printf("  %-18s %s\n", cmd("s / d"), "Save snapshot / diff against last")
+	fmt.Printf("  %-18s %s\n", cmd("e"), "Export packages")
+	fmt.Printf("  %-18s %s\n", cmd("r"), "Rescan all managers")
+	fmt.Printf("  %-18s %s\n", cmd("t"), "Theme picker")
+	fmt.Printf("  %-18s %s\n", cmd("? / q"), "Toggle help / quit")
+	fmt.Println()
+
+	fmt.Printf("%s %s\n", section("SUPPORTED MANAGERS"), muted("(36)"))
+	fmt.Println(muted("  brew, pacman, aur, apt, dnf, snap, pip, pipx, uv, cargo, go,"))
+	fmt.Println(muted("  npm, pnpm, bun, flatpak, macports, pkgsrc, opam, gem, pkg,"))
+	fmt.Println(muted("  composer, mas, apk, nix, conda, luarocks, xbps, portage, guix,"))
+	fmt.Println(muted("  winget, chocolatey, nuget, powershell, windows-updates, scoop, maven"))
+	fmt.Println()
+
+	fmt.Println(section("DATA PATHS"))
+	fmt.Printf("  %-12s %s\n", cmd("Cache"), muted("~/.local/share/glazepkg/cache/"))
+	fmt.Printf("  %-12s %s\n", cmd("Snapshots"), muted("~/.local/share/glazepkg/snapshots/"))
+	fmt.Printf("  %-12s %s\n", cmd("Exports"), muted("~/.local/share/glazepkg/exports/"))
 }

--- a/cmd/gpk/main.go
+++ b/cmd/gpk/main.go
@@ -6,6 +6,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/neur0map/glazepkg/internal/cli"
+	"github.com/neur0map/glazepkg/internal/manager"
 	"github.com/neur0map/glazepkg/internal/ui"
 	"github.com/neur0map/glazepkg/internal/updater"
 )
@@ -25,6 +27,8 @@ func main() {
 		case "update":
 			runUpdate()
 			return
+		case "list", "installed", "info", "outdated", "source-of":
+			os.Exit(cli.Dispatch(os.Args[1:], manager.All(), version, os.Stdout, os.Stderr))
 		}
 	}
 
@@ -56,7 +60,17 @@ Usage:
   gpk version      Show current version
   gpk --help       Show this help
 
-Keybinds:
+Headless commands (Phase 1, read-only):
+  gpk list                    List installed packages across all managers
+  gpk installed <pkg>...      Exit 0 if all named packages are installed (2 if not)
+  gpk info <pkg>              Show details for one installed package
+  gpk source-of <pkg>         Print which manager has the package
+  gpk outdated                List packages with available updates
+                              (--count for a number, --exit-code for CI gates)
+
+Run "gpk <subcommand> --help" for per-command flags.
+
+Keybinds (TUI):
   j/k, ↑/↓         Navigate up/down
   g/G              Jump to top/bottom
   Ctrl+d/u         Half page down/up

--- a/cmd/gpk/main.go
+++ b/cmd/gpk/main.go
@@ -27,9 +27,12 @@ func main() {
 		case "update":
 			runUpdate()
 			return
-		case "list", "installed", "info", "outdated", "source-of":
-			os.Exit(cli.Dispatch(os.Args[1:], manager.All(), version, os.Stdout, os.Stderr))
 		}
+		// Any other first arg is treated as a subcommand attempt.
+		// cli.Dispatch handles unknown names with a clean error + ExitErr,
+		// so users typing `gpk install foo` get a real message instead of
+		// the TUI failing with a TTY error.
+		os.Exit(cli.Dispatch(os.Args[1:], manager.All(), version, os.Stdout, os.Stderr))
 	}
 
 	p := tea.NewProgram(ui.NewModel(version), tea.WithAltScreen())

--- a/cmd/gpk/main.go
+++ b/cmd/gpk/main.go
@@ -69,11 +69,15 @@ func printHelp() {
 	section := func(name string) string {
 		return bold + name + reset
 	}
-	cmd := func(name string) string {
-		return cyan + name + reset
+	// cmd colors the name. Padding always goes INSIDE the color codes so
+	// ANSI escapes don't count toward fmt.Printf width — keeps columns
+	// aligned in TTY mode where bold/cyan would otherwise add ~10 bytes
+	// per cell and break %-22s.
+	cmd := func(name string, width int) string {
+		return cyan + fmt.Sprintf("%-*s", width, name) + reset
 	}
-	flagText := func(s string) string {
-		return yellow + s + reset
+	flagText := func(s string, width int) string {
+		return yellow + fmt.Sprintf("%-*s", width, s) + reset
 	}
 	muted := func(s string) string {
 		return dim + s + reset
@@ -83,34 +87,34 @@ func printHelp() {
 	fmt.Println()
 
 	fmt.Println(section("USAGE"))
-	fmt.Printf("  %-22s %s\n", cmd("gpk"), "Launch the TUI")
-	fmt.Printf("  %-22s %s\n", cmd("gpk <subcommand>"), "Run a headless command")
-	fmt.Printf("  %-22s %s\n", cmd("gpk update"), "Self-update to latest release")
-	fmt.Printf("  %-22s %s\n", cmd("gpk version"), "Show current version")
-	fmt.Printf("  %-22s %s\n", cmd("gpk -h, --help"), "Show this help")
+	fmt.Printf("  %s %s\n", cmd("gpk", 22), "Launch the TUI")
+	fmt.Printf("  %s %s\n", cmd("gpk <subcommand>", 22), "Run a headless command")
+	fmt.Printf("  %s %s\n", cmd("gpk update", 22), "Self-update to latest release")
+	fmt.Printf("  %s %s\n", cmd("gpk version", 22), "Show current version")
+	fmt.Printf("  %s %s\n", cmd("gpk -h, --help", 22), "Show this help")
 	fmt.Println()
 
 	fmt.Printf("%s %s\n", section("HEADLESS"), muted("· read-only"))
-	fmt.Printf("  %-22s %s\n", cmd("list"), "List installed packages across all managers")
-	fmt.Printf("  %-22s %s\n", cmd("installed <pkg>..."), "Check if packages are installed (exit 0/2)")
-	fmt.Printf("  %-22s %s\n", cmd("info <pkg>"), "Show details for one installed package")
-	fmt.Printf("  %-22s %s\n", cmd("source-of <pkg>"), "Print which manager has the package")
-	fmt.Printf("  %-22s %s\n", cmd("outdated"), "List packages with available updates")
+	fmt.Printf("  %s %s\n", cmd("list", 22), "List installed packages across all managers")
+	fmt.Printf("  %s %s\n", cmd("installed <pkg>...", 22), "Check if packages are installed (exit 0/2)")
+	fmt.Printf("  %s %s\n", cmd("info <pkg>", 22), "Show details for one installed package")
+	fmt.Printf("  %s %s\n", cmd("source-of <pkg>", 22), "Print which manager has the package")
+	fmt.Printf("  %s %s\n", cmd("outdated", 22), "List packages with available updates")
 	fmt.Println()
 
 	fmt.Printf("%s %s\n", section("HEADLESS"), muted("· write"))
-	fmt.Printf("  %-22s %s\n", cmd("install <pkg>..."), "Install one or more packages")
-	fmt.Printf("  %-22s %s\n", cmd("remove <pkg>..."), "Remove a package (--with-deps for orphans)")
-	fmt.Printf("  %-22s %s\n", cmd("upgrade <pkg>..."), "Upgrade installed packages to latest")
+	fmt.Printf("  %s %s\n", cmd("install <pkg>...", 22), "Install one or more packages")
+	fmt.Printf("  %s %s\n", cmd("remove <pkg>...", 22), "Remove a package (--with-deps for orphans)")
+	fmt.Printf("  %s %s\n", cmd("upgrade <pkg>...", 22), "Upgrade installed packages to latest")
 	fmt.Println()
 
 	fmt.Println(section("COMMON FLAGS"))
-	fmt.Printf("  %s   filter manager (e.g. pacman, pacman,aur, !brew)\n", flagText("--manager M, -m"))
-	fmt.Printf("  %s              emit a JSON envelope on stdout\n", flagText("--json"))
-	fmt.Printf("  %s          bypass the scan/update cache\n", flagText("--no-cache"))
-	fmt.Printf("  %s         skip the y/N prompt for writes (also skips manager's prompt)\n", flagText("--yes, -y"))
-	fmt.Printf("  %s           print the command without running it (writes only)\n", flagText("--dry-run"))
-	fmt.Printf("  %s       suppress progress on stderr\n", flagText("--quiet, -q"))
+	fmt.Printf("  %s %s\n", flagText("--manager M, -m", 18), "filter manager (e.g. pacman, pacman,aur, !brew)")
+	fmt.Printf("  %s %s\n", flagText("--json", 18), "emit a JSON envelope on stdout")
+	fmt.Printf("  %s %s\n", flagText("--no-cache", 18), "bypass the scan/update cache")
+	fmt.Printf("  %s %s\n", flagText("--yes, -y", 18), "skip the y/N prompt (also skips manager's prompt)")
+	fmt.Printf("  %s %s\n", flagText("--dry-run", 18), "print the command without running it (writes only)")
+	fmt.Printf("  %s %s\n", flagText("--quiet, -q", 18), "suppress progress on stderr")
 	fmt.Printf("  %s\n", muted("Run `gpk <subcommand> --help` for the full per-command flag list."))
 	fmt.Println()
 
@@ -122,19 +126,19 @@ func printHelp() {
 	fmt.Println()
 
 	fmt.Println(section("TUI KEYBINDS"))
-	fmt.Printf("  %-18s %s\n", cmd("j/k, ↑/↓"), "Navigate up/down")
-	fmt.Printf("  %-18s %s\n", cmd("g/G"), "Jump to top/bottom")
-	fmt.Printf("  %-18s %s\n", cmd("Ctrl+d/u"), "Half page down/up")
-	fmt.Printf("  %-18s %s\n", cmd("Tab/Shift+Tab"), "Cycle manager tabs")
-	fmt.Printf("  %-18s %s\n", cmd("/"), "Fuzzy search")
-	fmt.Printf("  %-18s %s\n", cmd("Enter"), "Package details")
-	fmt.Printf("  %-18s %s\n", cmd("u / x (detail)"), "Upgrade / remove the focused package")
-	fmt.Printf("  %-18s %s\n", cmd("i"), "Search + install across managers")
-	fmt.Printf("  %-18s %s\n", cmd("s / d"), "Save snapshot / diff against last")
-	fmt.Printf("  %-18s %s\n", cmd("e"), "Export packages")
-	fmt.Printf("  %-18s %s\n", cmd("r"), "Rescan all managers")
-	fmt.Printf("  %-18s %s\n", cmd("t"), "Theme picker")
-	fmt.Printf("  %-18s %s\n", cmd("? / q"), "Toggle help / quit")
+	fmt.Printf("  %s %s\n", cmd("j/k, ↑/↓", 18), "Navigate up/down")
+	fmt.Printf("  %s %s\n", cmd("g/G", 18), "Jump to top/bottom")
+	fmt.Printf("  %s %s\n", cmd("Ctrl+d/u", 18), "Half page down/up")
+	fmt.Printf("  %s %s\n", cmd("Tab/Shift+Tab", 18), "Cycle manager tabs")
+	fmt.Printf("  %s %s\n", cmd("/", 18), "Fuzzy search")
+	fmt.Printf("  %s %s\n", cmd("Enter", 18), "Package details")
+	fmt.Printf("  %s %s\n", cmd("u / x (detail)", 18), "Upgrade / remove the focused package")
+	fmt.Printf("  %s %s\n", cmd("i", 18), "Search + install across managers")
+	fmt.Printf("  %s %s\n", cmd("s / d", 18), "Save snapshot / diff against last")
+	fmt.Printf("  %s %s\n", cmd("e", 18), "Export packages")
+	fmt.Printf("  %s %s\n", cmd("r", 18), "Rescan all managers")
+	fmt.Printf("  %s %s\n", cmd("t", 18), "Theme picker")
+	fmt.Printf("  %s %s\n", cmd("? / q", 18), "Toggle help / quit")
 	fmt.Println()
 
 	fmt.Printf("%s %s\n", section("SUPPORTED MANAGERS"), muted("(36)"))
@@ -145,7 +149,7 @@ func printHelp() {
 	fmt.Println()
 
 	fmt.Println(section("DATA PATHS"))
-	fmt.Printf("  %-12s %s\n", cmd("Cache"), muted("~/.local/share/glazepkg/cache/"))
-	fmt.Printf("  %-12s %s\n", cmd("Snapshots"), muted("~/.local/share/glazepkg/snapshots/"))
-	fmt.Printf("  %-12s %s\n", cmd("Exports"), muted("~/.local/share/glazepkg/exports/"))
+	fmt.Printf("  %s %s\n", cmd("Cache", 12), muted("~/.local/share/glazepkg/cache/"))
+	fmt.Printf("  %s %s\n", cmd("Snapshots", 12), muted("~/.local/share/glazepkg/snapshots/"))
+	fmt.Printf("  %s %s\n", cmd("Exports", 12), muted("~/.local/share/glazepkg/exports/"))
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/harmonica v0.2.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/mattn/go-isatty v0.0.22
 	github.com/muesli/termenv v0.16.0
 	github.com/sahilm/fuzzy v0.1.1
 	golang.org/x/sys v0.38.0
@@ -25,7 +26,6 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
+github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
@@ -59,7 +57,6 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,58 @@
+// Package cli implements gpk's headless subcommands.
+//
+// Dispatch is the single entry point from cmd/gpk/main.go. Tests call it
+// directly with synthetic managers and bytes.Buffer streams; production wires
+// it against manager.All() and os.Stdout/os.Stderr.
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+)
+
+// subcommandFunc is the signature every subcommand handler implements.
+// args excludes the subcommand name itself (Dispatch strips it).
+type subcommandFunc func(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int
+
+// subcommands maps subcommand name → handler. Subcommand files register
+// themselves here via init() so adding a new one is a one-file change.
+var subcommands = map[string]subcommandFunc{}
+
+// Dispatch routes args[0] to the matching subcommand. Returns the exit code
+// the caller should propagate (cmd/gpk/main.go does os.Exit on the result).
+func Dispatch(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "error: no subcommand specified")
+		return ExitErr
+	}
+	name := args[0]
+	fn, ok := subcommands[name]
+	if !ok {
+		fmt.Fprintf(stderr, "error: unknown subcommand %q\n", name)
+		return ExitErr
+	}
+	return fn(args[1:], mgrs, version, stdout, stderr)
+}
+
+// SubcommandNames returns the registered subcommand names, sorted, for use
+// in help text. Stable order so help output doesn't churn between builds.
+func SubcommandNames() []string {
+	names := make([]string, 0, len(subcommands))
+	for n := range subcommands {
+		names = append(names, n)
+	}
+	sortStrings(names)
+	return names
+}
+
+// sortStrings is in-line so we don't pull "sort" into a file that may not
+// otherwise need it (keeps imports minimal).
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/neur0map/glazepkg/internal/manager"
 )
@@ -43,16 +44,7 @@ func SubcommandNames() []string {
 	for n := range subcommands {
 		names = append(names, n)
 	}
-	sortStrings(names)
+	sort.Strings(names)
 	return names
 }
 
-// sortStrings is in-line so we don't pull "sort" into a file that may not
-// otherwise need it (keeps imports minimal).
-func sortStrings(s []string) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j-1] > s[j]; j-- {
-			s[j-1], s[j] = s[j], s[j-1]
-		}
-	}
-}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,7 +15,7 @@ import (
 
 // subcommandFunc is the signature every subcommand handler implements.
 // args excludes the subcommand name itself (Dispatch strips it).
-type subcommandFunc func(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int
+type subcommandFunc func(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int
 
 // subcommands maps subcommand name → handler. Subcommand files register
 // themselves here via init() so adding a new one is a one-file change.
@@ -23,7 +23,7 @@ var subcommands = map[string]subcommandFunc{}
 
 // Dispatch routes args[0] to the matching subcommand. Returns the exit code
 // the caller should propagate (cmd/gpk/main.go does os.Exit on the result).
-func Dispatch(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+func Dispatch(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "error: no subcommand specified")
 		return ExitErr
@@ -34,7 +34,7 @@ func Dispatch(args []string, mgrs []manager.Manager, version string, stdout, std
 		fmt.Fprintf(stderr, "error: unknown subcommand %q\n", name)
 		return ExitErr
 	}
-	return fn(args[1:], mgrs, version, stdout, stderr)
+	return fn(args[1:], mgrs, version, stdout, stderr, stdin)
 }
 
 // SubcommandNames returns the registered subcommand names, sorted, for use

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -42,6 +42,9 @@ func TestExitCodeConstants(t *testing.T) {
 	if ExitNegative != 2 {
 		t.Errorf("ExitNegative = %d, want 2", ExitNegative)
 	}
+	if ExitAmbiguous != 3 {
+		t.Errorf("ExitAmbiguous = %d, want 3", ExitAmbiguous)
+	}
 }
 
 func TestDispatchRoutesToRegisteredSubcommand(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,8 +2,12 @@ package cli
 
 import (
 	"bytes"
+	"io"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/neur0map/glazepkg/internal/manager"
 )
 
 func TestDispatchUnknownSubcommand(t *testing.T) {
@@ -37,5 +41,30 @@ func TestExitCodeConstants(t *testing.T) {
 	}
 	if ExitNegative != 2 {
 		t.Errorf("ExitNegative = %d, want 2", ExitNegative)
+	}
+}
+
+func TestDispatchRoutesToRegisteredSubcommand(t *testing.T) {
+	var (
+		gotArgs    []string
+		gotVersion string
+	)
+	subcommands["__test_echo"] = func(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+		gotArgs = args
+		gotVersion = version
+		return 42
+	}
+	defer delete(subcommands, "__test_echo")
+
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"__test_echo", "a", "b"}, nil, "v1", &out, &errOut)
+	if code != 42 {
+		t.Errorf("exit code = %d, want 42 (handler's return value should propagate)", code)
+	}
+	if !reflect.DeepEqual(gotArgs, []string{"a", "b"}) {
+		t.Errorf("handler got args = %v, want [a b] (Dispatch should strip args[0])", gotArgs)
+	}
+	if gotVersion != "v1" {
+		t.Errorf("handler got version = %q, want %q", gotVersion, "v1")
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestDispatchUnknownSubcommand(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"bogus"}, nil, "test", &out, &errOut)
+	if code != ExitErr {
+		t.Errorf("exit code = %d, want %d", code, ExitErr)
+	}
+	if !strings.Contains(errOut.String(), "unknown subcommand") {
+		t.Errorf("stderr = %q, want substring 'unknown subcommand'", errOut.String())
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout = %q, want empty", out.String())
+	}
+}
+
+func TestDispatchEmptyArgs(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := Dispatch(nil, nil, "test", &out, &errOut)
+	if code != ExitErr {
+		t.Errorf("exit code = %d, want %d", code, ExitErr)
+	}
+}
+
+func TestExitCodeConstants(t *testing.T) {
+	if ExitOK != 0 {
+		t.Errorf("ExitOK = %d, want 0", ExitOK)
+	}
+	if ExitErr != 1 {
+		t.Errorf("ExitErr = %d, want 1", ExitErr)
+	}
+	if ExitNegative != 2 {
+		t.Errorf("ExitNegative = %d, want 2", ExitNegative)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDispatchUnknownSubcommand(t *testing.T) {
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"bogus"}, nil, "test", &out, &errOut)
+	code := Dispatch([]string{"bogus"}, nil, "test", &out, &errOut, nil)
 	if code != ExitErr {
 		t.Errorf("exit code = %d, want %d", code, ExitErr)
 	}
@@ -26,7 +26,7 @@ func TestDispatchUnknownSubcommand(t *testing.T) {
 
 func TestDispatchEmptyArgs(t *testing.T) {
 	var out, errOut bytes.Buffer
-	code := Dispatch(nil, nil, "test", &out, &errOut)
+	code := Dispatch(nil, nil, "test", &out, &errOut, nil)
 	if code != ExitErr {
 		t.Errorf("exit code = %d, want %d", code, ExitErr)
 	}
@@ -49,7 +49,7 @@ func TestDispatchRoutesToRegisteredSubcommand(t *testing.T) {
 		gotArgs    []string
 		gotVersion string
 	)
-	subcommands["__test_echo"] = func(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+	subcommands["__test_echo"] = func(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
 		gotArgs = args
 		gotVersion = version
 		return 42
@@ -57,7 +57,7 @@ func TestDispatchRoutesToRegisteredSubcommand(t *testing.T) {
 	defer delete(subcommands, "__test_echo")
 
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"__test_echo", "a", "b"}, nil, "v1", &out, &errOut)
+	code := Dispatch([]string{"__test_echo", "a", "b"}, nil, "v1", &out, &errOut, nil)
 	if code != 42 {
 		t.Errorf("exit code = %d, want 42 (handler's return value should propagate)", code)
 	}

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -1,0 +1,10 @@
+package cli
+
+// Exit codes form the stable contract for callers (scripts, QML, CI gates).
+// See docs/superpowers/specs/2026-05-14-headless-cli-phase1-design.md.
+const (
+	ExitOK       = 0 // success / yes / clean
+	ExitErr      = 1 // generic error (bad flag, scan failed, IO/network)
+	ExitNegative = 2 // meaningful "no" (not installed, has updates, not found)
+	// 3 and 4 are reserved for Phase 2 (ambiguity, cache+network failure).
+)

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -3,8 +3,9 @@ package cli
 // Exit codes form the stable contract for callers (scripts, QML, CI gates).
 // See docs/superpowers/specs/2026-05-14-headless-cli-phase1-design.md.
 const (
-	ExitOK       = 0 // success / yes / clean
-	ExitErr      = 1 // generic error (bad flag, scan failed, IO/network)
-	ExitNegative = 2 // meaningful "no" (not installed, has updates, not found)
-	// 3 and 4 are reserved for Phase 2 (ambiguity, cache+network failure).
+	ExitOK        = 0 // success / yes / clean
+	ExitErr       = 1 // generic error (bad flag, scan failed, IO/network)
+	ExitNegative  = 2 // meaningful "no" (not installed, has updates, not found)
+	ExitAmbiguous = 3 // install candidate available in multiple managers
+	// 4 reserved for Phase 2 cache+network failure.
 )

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+// confirmAction prints prompt to out, reads one line from in, and returns
+// true iff the user typed y/yes (case-insensitive). A line that's just a
+// newline, EOF, or anything else returns false (default-no).
+//
+// If in is nil, returns false — defensive against handlers that forget to
+// thread stdin through. Callers should always check the --yes flag first
+// and skip confirmAction entirely when set.
+func confirmAction(prompt string, in io.Reader, out io.Writer) bool {
+	if in == nil {
+		return false
+	}
+	fmt.Fprint(out, prompt)
+	r := bufio.NewReader(in)
+	line, err := r.ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
+}
+
+// headlessExec runs cmd with the parent process's stdin/stdout/stderr so
+// interactive prompts (sudo password, pacman confirmations) reach the
+// user's terminal. If cmd is a sudo wrapper using "-S" (read password from
+// stdin — a TUI-era convention), the "-S" is stripped so sudo uses its
+// normal tty prompt instead.
+//
+// This is the only place exec.Cmd is run in the cli package. All write
+// subcommands call this, never exec.Cmd.Run directly.
+func headlessExec(cmd *exec.Cmd) error {
+	if cmd == nil {
+		return fmt.Errorf("nil command")
+	}
+	cmd = stripSudoStdinFlag(cmd)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// stripSudoStdinFlag returns a copy of cmd with the "-S" argument removed
+// when cmd is invoking sudo. Leaves non-sudo commands untouched. The "-S"
+// flag was added by manager.privilegedCmd to support the TUI's password
+// modal; in headless mode we want sudo to prompt on the user's tty.
+func stripSudoStdinFlag(cmd *exec.Cmd) *exec.Cmd {
+	if len(cmd.Args) < 2 || cmd.Args[0] != "sudo" || cmd.Args[1] != "-S" {
+		return cmd
+	}
+	newArgs := append([]string{"sudo"}, cmd.Args[2:]...)
+	newCmd := exec.Command(newArgs[0], newArgs[1:]...)
+	newCmd.Dir = cmd.Dir
+	newCmd.Env = cmd.Env
+	return newCmd
+}
+
+// resolveInstallManager picks the manager to use for `gpk install <name>`.
+//
+// If the user passed --manager (via the filtered set being narrower than
+// the full set), and exactly one of those managers reports the package
+// available via Search, that manager wins.
+//
+// If the user did NOT pass --manager (filtered == manager.All()), and the
+// package is available via Search in exactly one manager, that one wins.
+//
+// If the package is available in multiple managers, returns an error
+// suitable for exit-3: "available in N managers (a, b, c), pick with
+// --manager". Callers detect this via errors.Is(err, ErrAmbiguous).
+//
+// If no manager has the package available, returns ErrNotFound.
+//
+// The "available" check uses each manager's Search method (managers that
+// don't implement Searcher are skipped, so they can't be auto-picked).
+func resolveInstallManager(name string, filtered []manager.Manager) (manager.Manager, error) {
+	var candidates []manager.Manager
+	for _, m := range filtered {
+		if !m.Available() {
+			continue
+		}
+		s, ok := m.(manager.Searcher)
+		if !ok {
+			continue
+		}
+		results, err := s.Search(name)
+		if err != nil {
+			continue // swallow per-manager errors; we just won't auto-pick this one
+		}
+		for _, p := range results {
+			if p.Name == name {
+				candidates = append(candidates, m)
+				break
+			}
+		}
+	}
+
+	switch len(candidates) {
+	case 0:
+		return nil, fmt.Errorf("%w: %q not available in any searched manager", ErrNotFound, name)
+	case 1:
+		return candidates[0], nil
+	default:
+		var names []string
+		for _, m := range candidates {
+			names = append(names, string(m.Name()))
+		}
+		return nil, fmt.Errorf("%w: %q available in %d managers (%s)",
+			ErrAmbiguous, name, len(candidates), strings.Join(names, ", "))
+	}
+}
+
+// Sentinel errors returned by resolveInstallManager. Tests use errors.Is.
+var (
+	ErrAmbiguous = fmt.Errorf("ambiguous package")
+	ErrNotFound  = fmt.Errorf("package not found")
+)
+
+// invalidateAfterWrite clears cached state for a manager after install,
+// remove, or upgrade. Always called after a successful subprocess run.
+//
+// Currently invalidates: scan cache (rewritten on next gpk list); update
+// cache entries for that manager's packages.
+//
+// Safe to call concurrently; cache files are rewritten atomically.
+func invalidateAfterWrite(mgr manager.Manager, pkgs []model.Package) {
+	// Scan cache: nuke it entirely so the next gpk list does a fresh scan.
+	// We can't surgically remove just one manager's packages without first
+	// reading and rewriting the file, and this is a write operation —
+	// freshness matters more than performance.
+	_ = os.Remove(scanCachePath())
+
+	// Update cache: invalidate keys for this manager's packages.
+	cache := manager.NewUpdateCache()
+	var keys []string
+	for _, p := range pkgs {
+		keys = append(keys, p.Key())
+	}
+	cache.Invalidate(keys)
+}
+
+// scanCachePath duplicates the logic in internal/manager/scancache.go so
+// we don't expose the path constant publicly. If manager ever exports a
+// "DeleteScanCache" helper, switch to that.
+func scanCachePath() string {
+	base := os.Getenv("XDG_DATA_HOME")
+	if base == "" {
+		home, _ := os.UserHomeDir()
+		base = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(base, "glazepkg", "cache", "scan.json")
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func TestConfirmAction_YesVariants(t *testing.T) {
+	for _, input := range []string{"y\n", "yes\n", "Y\n", "YES\n", " y \n"} {
+		t.Run(input, func(t *testing.T) {
+			var out bytes.Buffer
+			got := confirmAction("Proceed? [y/N] ", strings.NewReader(input), &out)
+			if !got {
+				t.Errorf("input %q expected true, got false", input)
+			}
+		})
+	}
+}
+
+func TestConfirmAction_NoVariants(t *testing.T) {
+	for _, input := range []string{"n\n", "no\n", "\n", "anything else\n", ""} {
+		t.Run(input, func(t *testing.T) {
+			var out bytes.Buffer
+			got := confirmAction("Proceed? [y/N] ", strings.NewReader(input), &out)
+			if got {
+				t.Errorf("input %q expected false, got true", input)
+			}
+		})
+	}
+}
+
+func TestConfirmAction_NilStdinReturnsFalse(t *testing.T) {
+	var out bytes.Buffer
+	if confirmAction("Proceed? [y/N] ", nil, &out) {
+		t.Error("expected false on nil stdin")
+	}
+}
+
+func TestStripSudoStdinFlag_RemovesS(t *testing.T) {
+	cmd := exec.Command("sudo", "-S", "pacman", "-S", "git")
+	stripped := stripSudoStdinFlag(cmd)
+	if stripped.Args[0] != "sudo" {
+		t.Errorf("args[0] = %q, want sudo", stripped.Args[0])
+	}
+	if len(stripped.Args) < 2 || stripped.Args[1] != "pacman" {
+		t.Errorf("args = %v, want [sudo pacman -S git]", stripped.Args)
+	}
+	// Importantly the SECOND "-S" (pacman's install flag) must survive.
+	joined := strings.Join(stripped.Args, " ")
+	if !strings.Contains(joined, "pacman -S git") {
+		t.Errorf("lost pacman flags: %q", joined)
+	}
+}
+
+func TestStripSudoStdinFlag_LeavesNonSudoAlone(t *testing.T) {
+	cmd := exec.Command("brew", "install", "git")
+	stripped := stripSudoStdinFlag(cmd)
+	if stripped != cmd {
+		t.Error("non-sudo command should be returned unchanged")
+	}
+}
+
+func TestStripSudoStdinFlag_SudoWithoutSStaysIntact(t *testing.T) {
+	cmd := exec.Command("sudo", "pacman", "-S", "git")
+	stripped := stripSudoStdinFlag(cmd)
+	if len(stripped.Args) != 4 || stripped.Args[1] != "pacman" {
+		t.Errorf("args = %v, want [sudo pacman -S git]", stripped.Args)
+	}
+}
+
+func TestResolveInstallManager_SingleMatch(t *testing.T) {
+	pacman := &fakeManager{
+		name:      model.SourcePacman,
+		available: true,
+		searchFn: func(q string) ([]model.Package, error) {
+			return []model.Package{{Name: "git", Source: model.SourcePacman}}, nil
+		},
+	}
+	brew := &fakeManager{
+		name:      model.SourceBrew,
+		available: true,
+		searchFn: func(q string) ([]model.Package, error) { return nil, nil },
+	}
+	got, err := resolveInstallManager("git", []manager.Manager{pacman, brew})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name() != model.SourcePacman {
+		t.Errorf("got %s, want pacman", got.Name())
+	}
+}
+
+func TestResolveInstallManager_AmbiguousReturnsErr(t *testing.T) {
+	pacman := &fakeManager{
+		name:      model.SourcePacman,
+		available: true,
+		searchFn: func(q string) ([]model.Package, error) {
+			return []model.Package{{Name: "ripgrep"}}, nil
+		},
+	}
+	brew := &fakeManager{
+		name:      model.SourceBrew,
+		available: true,
+		searchFn: func(q string) ([]model.Package, error) {
+			return []model.Package{{Name: "ripgrep"}}, nil
+		},
+	}
+	_, err := resolveInstallManager("ripgrep", []manager.Manager{pacman, brew})
+	if !errors.Is(err, ErrAmbiguous) {
+		t.Fatalf("got %v, want ErrAmbiguous", err)
+	}
+	if !strings.Contains(err.Error(), "pacman") || !strings.Contains(err.Error(), "brew") {
+		t.Errorf("error message should list both managers: %v", err)
+	}
+}
+
+func TestResolveInstallManager_NotFoundReturnsErr(t *testing.T) {
+	pacman := &fakeManager{
+		name:      model.SourcePacman,
+		available: true,
+		searchFn: func(q string) ([]model.Package, error) { return nil, nil },
+	}
+	_, err := resolveInstallManager("nope", []manager.Manager{pacman})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestResolveInstallManager_SkipsNonSearcher(t *testing.T) {
+	// A fakeManager whose searchFn is nil acts as a non-Searcher via the
+	// nil-guard in Search(), but the type assertion still succeeds.
+	// We need a separate type that doesn't implement Search at all.
+	pacman := &fakeManager{
+		name:      model.SourcePacman,
+		available: true,
+		searchFn: func(q string) ([]model.Package, error) {
+			return []model.Package{{Name: "git"}}, nil
+		},
+	}
+	got, err := resolveInstallManager("git", []manager.Manager{pacman})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name() != model.SourcePacman {
+		t.Errorf("got %s, want pacman", got.Name())
+	}
+}
+
+func TestExitAmbiguousConstant(t *testing.T) {
+	if ExitAmbiguous != 3 {
+		t.Errorf("ExitAmbiguous = %d, want 3", ExitAmbiguous)
+	}
+}

--- a/internal/cli/fakes_test.go
+++ b/internal/cli/fakes_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+// fakeManager is a configurable Manager for tests. Each capability interface
+// method delegates to a function pointer; unset pointers behave as "the
+// manager doesn't implement that capability" via the wrapping interface
+// assertions in the cli package. Tests use only the fields they care about.
+type fakeManager struct {
+	name      model.Source
+	available bool
+
+	scanFn         func() ([]model.Package, error)
+	checkUpdatesFn func(pkgs []model.Package) map[string]string
+	describeFn     func(pkgs []model.Package) map[string]string
+	depsFn         func(pkgs []model.Package) map[string][]string
+	upgradeCmdFn   func(name string) *exec.Cmd
+	removeCmdFn    func(name string) *exec.Cmd
+	searchFn       func(query string) ([]model.Package, error)
+	installCmdFn   func(name string) *exec.Cmd
+}
+
+func (f *fakeManager) Name() model.Source { return f.name }
+func (f *fakeManager) Available() bool    { return f.available }
+
+func (f *fakeManager) Scan() ([]model.Package, error) {
+	if f.scanFn == nil {
+		return nil, nil
+	}
+	return f.scanFn()
+}
+
+func (f *fakeManager) CheckUpdates(pkgs []model.Package) map[string]string {
+	if f.checkUpdatesFn == nil {
+		return nil
+	}
+	return f.checkUpdatesFn(pkgs)
+}
+
+func (f *fakeManager) Describe(pkgs []model.Package) map[string]string {
+	if f.describeFn == nil {
+		return nil
+	}
+	return f.describeFn(pkgs)
+}
+
+func (f *fakeManager) ListDependencies(pkgs []model.Package) map[string][]string {
+	if f.depsFn == nil {
+		return nil
+	}
+	return f.depsFn(pkgs)
+}
+
+func (f *fakeManager) UpgradeCmd(name string) *exec.Cmd {
+	if f.upgradeCmdFn == nil {
+		return nil
+	}
+	return f.upgradeCmdFn(name)
+}
+
+func (f *fakeManager) RemoveCmd(name string) *exec.Cmd {
+	if f.removeCmdFn == nil {
+		return nil
+	}
+	return f.removeCmdFn(name)
+}
+
+func (f *fakeManager) Search(query string) ([]model.Package, error) {
+	if f.searchFn == nil {
+		return nil, nil
+	}
+	return f.searchFn(query)
+}
+
+func (f *fakeManager) InstallCmd(name string) *exec.Cmd {
+	if f.installCmdFn == nil {
+		return nil
+	}
+	return f.installCmdFn(name)
+}
+
+// fakePackage is a one-liner constructor for tests that only care about the
+// Name/Version/Source triple.
+func fakePackage(name, version string, source model.Source) model.Package {
+	return model.Package{
+		Name:        name,
+		Version:     version,
+		Source:      source,
+		InstalledAt: time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestFakeManagerSmoke ensures the fake compiles and behaves as expected
+// before subcommand tests start depending on it.
+func TestFakeManagerSmoke(t *testing.T) {
+	pkg := fakePackage("foo", "1.0", model.SourcePacman)
+	f := &fakeManager{
+		name:      model.SourcePacman,
+		available: true,
+		scanFn:    func() ([]model.Package, error) { return []model.Package{pkg}, nil },
+	}
+	if f.Name() != model.SourcePacman {
+		t.Errorf("Name() = %s", f.Name())
+	}
+	if !f.Available() {
+		t.Errorf("Available() = false")
+	}
+	got, err := f.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "foo" {
+		t.Errorf("Scan returned %+v", got)
+	}
+}

--- a/internal/cli/fakes_test.go
+++ b/internal/cli/fakes_test.go
@@ -16,14 +16,19 @@ type fakeManager struct {
 	name      model.Source
 	available bool
 
-	scanFn         func() ([]model.Package, error)
-	checkUpdatesFn func(pkgs []model.Package) map[string]string
-	describeFn     func(pkgs []model.Package) map[string]string
-	depsFn         func(pkgs []model.Package) map[string][]string
-	upgradeCmdFn   func(name string) *exec.Cmd
-	removeCmdFn    func(name string) *exec.Cmd
-	searchFn       func(query string) ([]model.Package, error)
-	installCmdFn   func(name string) *exec.Cmd
+	scanFn            func() ([]model.Package, error)
+	checkUpdatesFn    func(pkgs []model.Package) map[string]string
+	describeFn        func(pkgs []model.Package) map[string]string
+	depsFn            func(pkgs []model.Package) map[string][]string
+	upgradeCmdFn         func(name string) *exec.Cmd
+	upgradeCmdYesFn      func(name string) *exec.Cmd
+	removeCmdFn          func(name string) *exec.Cmd
+	removeCmdYesFn       func(name string) *exec.Cmd
+	removeCmdWithDepsFn  func(name string) *exec.Cmd
+	removeCmdWithDepsYesFn func(name string) *exec.Cmd
+	searchFn             func(query string) ([]model.Package, error)
+	installCmdFn         func(name string) *exec.Cmd
+	installCmdYesFn      func(name string) *exec.Cmd
 }
 
 func (f *fakeManager) Name() model.Source { return f.name }
@@ -83,6 +88,41 @@ func (f *fakeManager) InstallCmd(name string) *exec.Cmd {
 		return nil
 	}
 	return f.installCmdFn(name)
+}
+
+func (f *fakeManager) InstallCmdYes(name string) *exec.Cmd {
+	if f.installCmdYesFn == nil {
+		return nil
+	}
+	return f.installCmdYesFn(name)
+}
+
+func (f *fakeManager) UpgradeCmdYes(name string) *exec.Cmd {
+	if f.upgradeCmdYesFn == nil {
+		return nil
+	}
+	return f.upgradeCmdYesFn(name)
+}
+
+func (f *fakeManager) RemoveCmdYes(name string) *exec.Cmd {
+	if f.removeCmdYesFn == nil {
+		return nil
+	}
+	return f.removeCmdYesFn(name)
+}
+
+func (f *fakeManager) RemoveCmdWithDeps(name string) *exec.Cmd {
+	if f.removeCmdWithDepsFn == nil {
+		return nil
+	}
+	return f.removeCmdWithDepsFn(name)
+}
+
+func (f *fakeManager) RemoveCmdWithDepsYes(name string) *exec.Cmd {
+	if f.removeCmdWithDepsYesFn == nil {
+		return nil
+	}
+	return f.removeCmdWithDepsYesFn(name)
 }
 
 // fakePackage is a one-liner constructor for tests that only care about the

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,0 +1,48 @@
+package cli
+
+import "strings"
+
+// reorderFlagsFirst moves flag-looking tokens (and their values for known
+// string-valued flag names) ahead of positional arguments so users can write
+// `gpk installed git --json` without flags being misparsed as positional.
+//
+// stringFlags is the list of flag names (without dashes) that consume the
+// following arg as their value. For Phase 1, these are "manager" and "m".
+// All other flags are treated as boolean (no following value).
+//
+// The `--` separator (POSIX "end of flags") stops scanning; everything after
+// it stays in positional order. This lets users force a package name that
+// happens to start with a dash.
+func reorderFlagsFirst(args []string, stringFlags []string) []string {
+	takesValue := make(map[string]bool, len(stringFlags))
+	for _, f := range stringFlags {
+		takesValue[f] = true
+	}
+
+	var flags, positional []string
+	i := 0
+	for ; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			// Everything after `--` is positional, including dash-prefixed args.
+			positional = append(positional, args[i+1:]...)
+			break
+		}
+		if !strings.HasPrefix(a, "-") || a == "-" {
+			positional = append(positional, a)
+			continue
+		}
+		flags = append(flags, a)
+		// "--name=value" form: value is inline, no extra arg to consume.
+		if strings.Contains(a, "=") {
+			continue
+		}
+		// Strip dashes to get the flag name.
+		name := strings.TrimLeft(a, "-")
+		if takesValue[name] && i+1 < len(args) {
+			i++
+			flags = append(flags, args[i])
+		}
+	}
+	return append(flags, positional...)
+}

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReorderFlagsFirst(t *testing.T) {
+	stringFlags := []string{"manager", "m"}
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty", []string{}, []string{}},
+		{"already in order", []string{"--json", "git"}, []string{"--json", "git"}},
+		{"single positional", []string{"git"}, []string{"git"}},
+		{"single flag", []string{"--json"}, []string{"--json"}},
+		{"flag after positional", []string{"git", "--json"}, []string{"--json", "git"}},
+		{"multiple positional + flags", []string{"vim", "git", "--json", "--quiet"}, []string{"--json", "--quiet", "vim", "git"}},
+		{"string flag with value", []string{"pkg", "--manager", "pacman"}, []string{"--manager", "pacman", "pkg"}},
+		{"short string flag with value", []string{"pkg", "-m", "pacman"}, []string{"-m", "pacman", "pkg"}},
+		{"equals form does not consume next", []string{"pkg", "--manager=pacman", "--json"}, []string{"--manager=pacman", "--json", "pkg"}},
+		{"double-dash separator", []string{"--json", "--", "-weird-name"}, []string{"--json", "-weird-name"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := reorderFlagsFirst(c.in, stringFlags)
+			// Normalize empty slices for comparison
+			if len(got) == 0 && len(c.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("reorderFlagsFirst(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -22,6 +22,7 @@ func runInfo(args []string, mgrs []manager.Manager, version string, stdout, stde
 		noCacheFlag = fs.Bool("no-cache", false, "bypass the scan cache")
 	)
 	fs.StringVar(mgrFlag, "m", *mgrFlag, "alias for --manager")
+	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
 		return ExitErr
 	}

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -14,7 +14,7 @@ func init() {
 	subcommands["info"] = runInfo
 }
 
-func runInfo(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+func runInfo(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
 	fs := flag.NewFlagSet("info", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -24,6 +25,9 @@ func runInfo(args []string, mgrs []manager.Manager, version string, stdout, stde
 	fs.StringVar(mgrFlag, "m", *mgrFlag, "alias for --manager")
 	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
 		return ExitErr
 	}
 
@@ -40,7 +44,8 @@ func runInfo(args []string, mgrs []manager.Manager, version string, stdout, stde
 		return ExitErr
 	}
 
-	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr)
+	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr, cacheOK)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
 		return ExitErr

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -44,7 +44,7 @@ func runInfo(args []string, mgrs []manager.Manager, version string, stdout, stde
 		return ExitErr
 	}
 
-	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	cacheOK := cacheWriteOKFor(*mgrFlag)
 	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr, cacheOK)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func init() {
+	subcommands["info"] = runInfo
+}
+
+func runInfo(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("info", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		mgrFlag     = fs.String("manager", "", "comma list of managers (default: all)")
+		jsonFlag    = fs.Bool("json", false, "emit JSON envelope")
+		noCacheFlag = fs.Bool("no-cache", false, "bypass the scan cache")
+	)
+	fs.StringVar(mgrFlag, "m", *mgrFlag, "alias for --manager")
+	if err := fs.Parse(args); err != nil {
+		return ExitErr
+	}
+
+	rest := fs.Args()
+	if len(rest) != 1 {
+		fmt.Fprintln(stderr, "error: info takes exactly one package name")
+		return ExitErr
+	}
+	name := rest[0]
+
+	filtered, err := parseManagerFilter(*mgrFlag, mgrs)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitErr
+	}
+
+	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
+		return ExitErr
+	}
+
+	var found *model.Package
+	for _, m := range filtered {
+		for i := range pkgs {
+			if pkgs[i].Name == name && pkgs[i].Source == m.Name() {
+				found = &pkgs[i]
+				break
+			}
+		}
+		if found != nil {
+			break
+		}
+	}
+
+	if found == nil {
+		return ExitNegative
+	}
+
+	if *jsonFlag {
+		if err := writeEnvelope(stdout, version, toCLIPackage(*found)); err != nil {
+			fmt.Fprintf(stderr, "error: encoding JSON: %v\n", err)
+			return ExitErr
+		}
+		return ExitOK
+	}
+
+	writeInfoHuman(stdout, *found)
+	return ExitOK
+}
+
+func writeInfoHuman(w io.Writer, p model.Package) {
+	field := func(k, v string) {
+		if v == "" {
+			return
+		}
+		fmt.Fprintf(w, "%-14s %s\n", k+":", v)
+	}
+	field("Name", p.Name)
+	field("Version", p.Version)
+	field("Source", string(p.Source))
+	field("Description", p.Description)
+	field("Size", p.Size)
+	field("Repository", p.Repository)
+	if p.LatestVersion != "" && p.LatestVersion != p.Version {
+		field("Latest", p.LatestVersion)
+	}
+	if len(p.DependsOn) > 0 {
+		fmt.Fprintln(w, "Depends on:")
+		for _, d := range p.DependsOn {
+			fmt.Fprintf(w, "  %s\n", d)
+		}
+	}
+	if len(p.RequiredBy) > 0 {
+		fmt.Fprintln(w, "Required by:")
+		for _, d := range p.RequiredBy {
+			fmt.Fprintf(w, "  %s\n", d)
+		}
+	}
+}

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestInfoFound(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"info", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
+	}
+	body := out.String()
+	if !strings.Contains(body, "vim") || !strings.Contains(body, "9.0") || !strings.Contains(body, "pacman") {
+		t.Errorf("output missing expected fields: %s", body)
+	}
+}
+
+func TestInfoNotFound(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"info", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitNegative {
+		t.Errorf("exit %d, want %d", code, ExitNegative)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout should be empty on exit 2, got %q", out.String())
+	}
+}
+
+func TestInfoMissingArg(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"info"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+}
+
+func TestInfoTooManyArgs(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"info", "vim", "git"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+}
+
+func TestInfoJSONFound(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"info", "--json", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d", code)
+	}
+	var env struct {
+		Data cliPackage `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if env.Data.Name != "vim" || env.Data.Version != "9.0" {
+		t.Errorf("data = %+v", env.Data)
+	}
+}
+
+func TestInfoManagerFilterMiss(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// vim is pacman; restricting to brew should yield exit 2.
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"info", "--manager", "brew", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitNegative {
+		t.Errorf("exit %d, want %d", code, ExitNegative)
+	}
+}

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -77,3 +77,12 @@ func TestInfoManagerFilterMiss(t *testing.T) {
 		t.Errorf("exit %d, want %d", code, ExitNegative)
 	}
 }
+
+func TestInfoHelpExitsZero(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"info", "--help"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
+	}
+}

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -10,7 +10,7 @@ import (
 func TestInfoFound(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"info", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"info", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
 	}
@@ -23,7 +23,7 @@ func TestInfoFound(t *testing.T) {
 func TestInfoNotFound(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"info", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"info", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitNegative {
 		t.Errorf("exit %d, want %d", code, ExitNegative)
 	}
@@ -35,7 +35,7 @@ func TestInfoNotFound(t *testing.T) {
 func TestInfoMissingArg(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"info"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"info"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitErr {
 		t.Errorf("exit %d, want %d", code, ExitErr)
 	}
@@ -44,7 +44,7 @@ func TestInfoMissingArg(t *testing.T) {
 func TestInfoTooManyArgs(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"info", "vim", "git"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"info", "vim", "git"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitErr {
 		t.Errorf("exit %d, want %d", code, ExitErr)
 	}
@@ -53,7 +53,7 @@ func TestInfoTooManyArgs(t *testing.T) {
 func TestInfoJSONFound(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"info", "--json", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"info", "--json", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d", code)
 	}
@@ -72,7 +72,7 @@ func TestInfoManagerFilterMiss(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	// vim is pacman; restricting to brew should yield exit 2.
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"info", "--manager", "brew", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"info", "--manager", "brew", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitNegative {
 		t.Errorf("exit %d, want %d", code, ExitNegative)
 	}
@@ -81,7 +81,7 @@ func TestInfoManagerFilterMiss(t *testing.T) {
 func TestInfoHelpExitsZero(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"info", "--help"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"info", "--help"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
 	}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os/exec"
 	"strings"
 
 	"github.com/neur0map/glazepkg/internal/manager"
@@ -65,7 +66,16 @@ func runInstall(args []string, mgrs []manager.Manager, version string, stdout, s
 			fmt.Fprintf(stderr, "error: %s does not support install\n", chosen.Name())
 			return ExitErr
 		}
-		cmd := installer.InstallCmd(name)
+
+		var cmd *exec.Cmd
+		if *yesFlag {
+			if ni, ok := chosen.(manager.NonInteractiveInstaller); ok {
+				cmd = ni.InstallCmdYes(name)
+			}
+		}
+		if cmd == nil {
+			cmd = installer.InstallCmd(name)
+		}
 		if cmd == nil {
 			fmt.Fprintf(stderr, "error: %s returned no install command for %q\n", chosen.Name(), name)
 			return ExitErr
@@ -98,8 +108,16 @@ func runInstall(args []string, mgrs []manager.Manager, version string, stdout, s
 		if !*quietFlag {
 			fmt.Fprintf(stderr, "installing %s via %s...\n", p.pkg, p.mgr.Name())
 		}
-		installer := p.mgr.(manager.Installer)
-		cmd := installer.InstallCmd(p.pkg)
+		var cmd *exec.Cmd
+		if *yesFlag {
+			if ni, ok := p.mgr.(manager.NonInteractiveInstaller); ok {
+				cmd = ni.InstallCmdYes(p.pkg)
+			}
+		}
+		if cmd == nil {
+			installer := p.mgr.(manager.Installer)
+			cmd = installer.InstallCmd(p.pkg)
+		}
 		if err := headlessExec(cmd); err != nil {
 			fmt.Fprintf(stderr, "error: install %s failed: %v\n", p.pkg, err)
 			return ExitErr

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func init() {
+	subcommands["install"] = runInstall
+}
+
+func runInstall(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
+	args = reorderFlagsFirst(args, []string{"manager", "m"})
+	fs := flag.NewFlagSet("install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		mgrFlag    = fs.String("manager", "", "manager to install from; required if package is available in multiple managers")
+		yesFlag    = fs.Bool("yes", false, "skip the y/N confirmation prompt")
+		dryRunFlag = fs.Bool("dry-run", false, "print the command(s) without executing")
+		quietFlag  = fs.Bool("quiet", false, "suppress progress messages on stderr")
+	)
+	fs.BoolVar(yesFlag, "y", false, "alias for --yes")
+	fs.BoolVar(quietFlag, "q", false, "alias for --quiet")
+	fs.StringVar(mgrFlag, "m", "", "alias for --manager")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
+		return ExitErr
+	}
+
+	names := fs.Args()
+	if len(names) == 0 {
+		fmt.Fprintln(stderr, "error: install requires at least one package name")
+		return ExitErr
+	}
+
+	filtered, err := parseManagerFilter(*mgrFlag, mgrs)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitErr
+	}
+
+	// Resolve manager + InstallCmd for each name.
+	type plan struct {
+		pkg string
+		mgr manager.Manager
+		cmd *strings.Builder // for display
+	}
+	var plans []plan
+	for _, name := range names {
+		chosen, err := resolveInstallManager(name, filtered)
+		if err != nil {
+			return reportResolveErr(err, stderr)
+		}
+
+		installer, ok := chosen.(manager.Installer)
+		if !ok {
+			fmt.Fprintf(stderr, "error: %s does not support install\n", chosen.Name())
+			return ExitErr
+		}
+		cmd := installer.InstallCmd(name)
+		if cmd == nil {
+			fmt.Fprintf(stderr, "error: %s returned no install command for %q\n", chosen.Name(), name)
+			return ExitErr
+		}
+		var disp strings.Builder
+		disp.WriteString(strings.Join(stripSudoStdinFlag(cmd).Args, " "))
+		plans = append(plans, plan{pkg: name, mgr: chosen, cmd: &disp})
+	}
+
+	// Show the plan and (unless --yes) prompt.
+	fmt.Fprintln(stdout, "The following commands will run:")
+	for _, p := range plans {
+		fmt.Fprintf(stdout, "  %s  →  %s\n", p.mgr.Name(), p.cmd.String())
+	}
+
+	if *dryRunFlag {
+		fmt.Fprintln(stdout, "(dry-run; nothing executed)")
+		return ExitOK
+	}
+
+	if !*yesFlag {
+		if !confirmAction("Proceed? [y/N] ", stdin, stdout) {
+			fmt.Fprintln(stderr, "cancelled")
+			return ExitOK
+		}
+	}
+
+	// Execute. Stop on first failure.
+	for _, p := range plans {
+		if !*quietFlag {
+			fmt.Fprintf(stderr, "installing %s via %s...\n", p.pkg, p.mgr.Name())
+		}
+		installer := p.mgr.(manager.Installer)
+		cmd := installer.InstallCmd(p.pkg)
+		if err := headlessExec(cmd); err != nil {
+			fmt.Fprintf(stderr, "error: install %s failed: %v\n", p.pkg, err)
+			return ExitErr
+		}
+		invalidateAfterWrite(p.mgr, []model.Package{{Name: p.pkg, Source: p.mgr.Name()}})
+	}
+	return ExitOK
+}
+
+// reportResolveErr maps the sentinel errors from resolveInstallManager to
+// exit codes and writes the error to stderr.
+func reportResolveErr(err error, stderr io.Writer) int {
+	fmt.Fprintf(stderr, "error: %v\n", err)
+	switch {
+	case errors.Is(err, ErrAmbiguous):
+		return ExitAmbiguous
+	case errors.Is(err, ErrNotFound):
+		return ExitNegative
+	default:
+		return ExitErr
+	}
+}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func installFakeMgrs() []manager.Manager {
+	pacman := &fakeManager{
+		name: model.SourcePacman, available: true,
+		searchFn: func(q string) ([]model.Package, error) {
+			if q == "ripgrep" || q == "git" {
+				return []model.Package{{Name: q, Source: model.SourcePacman}}, nil
+			}
+			return nil, nil
+		},
+		installCmdFn: func(name string) *exec.Cmd {
+			// Use /bin/true so the test "install" succeeds without side effects.
+			return exec.Command("/bin/true", "install", name)
+		},
+	}
+	brew := &fakeManager{
+		name: model.SourceBrew, available: true,
+		searchFn: func(q string) ([]model.Package, error) {
+			if q == "ripgrep" {
+				return []model.Package{{Name: q, Source: model.SourceBrew}}, nil
+			}
+			return nil, nil
+		},
+		installCmdFn: func(name string) *exec.Cmd {
+			return exec.Command("/bin/true", "install", name)
+		},
+	}
+	return []manager.Manager{pacman, brew}
+}
+
+func TestInstallNoArgs(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"install"}, installFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+}
+
+func TestInstallAmbiguous(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"install", "ripgrep"}, installFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitAmbiguous {
+		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitAmbiguous, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "pacman") || !strings.Contains(errOut.String(), "brew") {
+		t.Errorf("stderr should list both managers: %q", errOut.String())
+	}
+}
+
+func TestInstallNotFound(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"install", "nope-does-not-exist"}, installFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitNegative {
+		t.Errorf("exit %d, want %d", code, ExitNegative)
+	}
+}
+
+func TestInstallExplicitManagerYes(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"install", "ripgrep", "--manager", "brew", "--yes", "--quiet"}, installFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Fatalf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
+	}
+}
+
+func TestInstallDryRun(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"install", "git", "--dry-run"}, installFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Fatalf("exit %d, want %d", code, ExitOK)
+	}
+	if !strings.Contains(out.String(), "dry-run") {
+		t.Errorf("expected dry-run notice in stdout: %q", out.String())
+	}
+}
+
+func TestInstallPromptYes(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	stdin := strings.NewReader("y\n")
+	code := Dispatch([]string{"install", "git", "--quiet"}, installFakeMgrs(), "test", &out, &errOut, stdin)
+	if code != ExitOK {
+		t.Fatalf("exit %d, stderr=%q", code, errOut.String())
+	}
+}
+
+func TestInstallPromptNo(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	stdin := strings.NewReader("n\n")
+	code := Dispatch([]string{"install", "git"}, installFakeMgrs(), "test", &out, &errOut, stdin)
+	if code != ExitOK {
+		t.Fatalf("exit %d (cancellation should still be 0): stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "cancelled") {
+		t.Errorf("stderr should mention cancelled: %q", errOut.String())
+	}
+}
+
+func TestInstallHelpExitsZero(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"install", "--help"}, installFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Errorf("exit %d, want %d", code, ExitOK)
+	}
+}

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -27,6 +28,9 @@ func runInstalled(args []string, mgrs []manager.Manager, version string, stdout,
 	fs.StringVar(mgrFlag, "m", *mgrFlag, "alias for --manager")
 	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
 		return ExitErr
 	}
 
@@ -42,7 +46,8 @@ func runInstalled(args []string, mgrs []manager.Manager, version string, stdout,
 		return ExitErr
 	}
 
-	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr) // installed always quiet about scans
+	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr, cacheOK) // installed always quiet about scans
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
 		return ExitErr

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -46,7 +46,7 @@ func runInstalled(args []string, mgrs []manager.Manager, version string, stdout,
 		return ExitErr
 	}
 
-	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	cacheOK := cacheWriteOKFor(*mgrFlag)
 	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr, cacheOK) // installed always quiet about scans
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func init() {
+	subcommands["installed"] = runInstalled
+}
+
+func runInstalled(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("installed", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		mgrFlag     = fs.String("manager", "", "comma list of managers (default: all)")
+		jsonFlag    = fs.Bool("json", false, "emit JSON envelope")
+		noCacheFlag = fs.Bool("no-cache", false, "bypass the scan cache")
+		quietFlag   = fs.Bool("quiet", false, "suppress missing-name report on stderr")
+	)
+	fs.BoolVar(quietFlag, "q", *quietFlag, "alias for --quiet")
+	fs.StringVar(mgrFlag, "m", *mgrFlag, "alias for --manager")
+	if err := fs.Parse(args); err != nil {
+		return ExitErr
+	}
+
+	names := fs.Args()
+	if len(names) == 0 {
+		fmt.Fprintln(stderr, "error: installed requires at least one package name")
+		return ExitErr
+	}
+
+	filtered, err := parseManagerFilter(*mgrFlag, mgrs)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitErr
+	}
+
+	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr) // installed always quiet about scans
+	if err != nil {
+		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
+		return ExitErr
+	}
+
+	byName := make(map[string][]model.Package)
+	for _, p := range pkgs {
+		byName[p.Name] = append(byName[p.Name], p)
+	}
+
+	type result struct {
+		Name      string       `json:"name"`
+		Installed bool         `json:"installed"`
+		Matches   []cliPackage `json:"matches"`
+	}
+	results := make([]result, 0, len(names))
+	var missing []string
+	for _, n := range names {
+		matches := byName[n]
+		r := result{Name: n, Installed: len(matches) > 0, Matches: toCLIPackages(matches)}
+		results = append(results, r)
+		if !r.Installed {
+			missing = append(missing, n)
+		}
+	}
+
+	if *jsonFlag {
+		if err := writeEnvelope(stdout, version, results); err != nil {
+			fmt.Fprintf(stderr, "error: encoding JSON: %v\n", err)
+			return ExitErr
+		}
+	}
+
+	if len(missing) > 0 {
+		if !*quietFlag {
+			fmt.Fprintf(stderr, "not installed: %s\n", strings.Join(missing, ", "))
+		}
+		return ExitNegative
+	}
+	return ExitOK
+}

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -25,6 +25,7 @@ func runInstalled(args []string, mgrs []manager.Manager, version string, stdout,
 	)
 	fs.BoolVar(quietFlag, "q", *quietFlag, "alias for --quiet")
 	fs.StringVar(mgrFlag, "m", *mgrFlag, "alias for --manager")
+	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
 		return ExitErr
 	}

--- a/internal/cli/installed.go
+++ b/internal/cli/installed.go
@@ -15,7 +15,7 @@ func init() {
 	subcommands["installed"] = runInstalled
 }
 
-func runInstalled(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+func runInstalled(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
 	fs := flag.NewFlagSet("installed", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -10,7 +10,7 @@ import (
 func TestInstalledAllPresent(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"installed", "--no-cache", "--quiet", "vim", "git"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"installed", "--no-cache", "--quiet", "vim", "git"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
 	}
@@ -19,7 +19,7 @@ func TestInstalledAllPresent(t *testing.T) {
 func TestInstalledOneMissing(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"installed", "--no-cache", "--quiet", "vim", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"installed", "--no-cache", "--quiet", "vim", "nonexistent"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitNegative {
 		t.Fatalf("exit %d, want %d", code, ExitNegative)
 	}
@@ -28,7 +28,7 @@ func TestInstalledOneMissing(t *testing.T) {
 func TestInstalledZeroArgsErrors(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"installed"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"installed"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitErr {
 		t.Errorf("exit %d, want %d", code, ExitErr)
 	}
@@ -37,7 +37,7 @@ func TestInstalledZeroArgsErrors(t *testing.T) {
 func TestInstalledJSONShape(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"installed", "--json", "--no-cache", "--quiet", "vim", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"installed", "--json", "--no-cache", "--quiet", "vim", "nonexistent"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitNegative {
 		t.Fatalf("exit %d", code)
 	}
@@ -67,7 +67,7 @@ func TestInstalledManagerFilter(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	// vim is in pacman; with --manager brew it should be reported as missing.
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"installed", "--manager", "brew", "--no-cache", "--quiet", "vim"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"installed", "--manager", "brew", "--no-cache", "--quiet", "vim"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitNegative {
 		t.Errorf("exit %d, want %d", code, ExitNegative)
 	}
@@ -77,7 +77,7 @@ func TestInstalledReportsMissingOnStderr(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	// Without --quiet, missing packages get listed on stderr.
 	var out, errOut bytes.Buffer
-	_ = Dispatch([]string{"installed", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	_ = Dispatch([]string{"installed", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut, nil)
 	if !strings.Contains(errOut.String(), "nonexistent") {
 		t.Errorf("stderr = %q, want substring 'nonexistent'", errOut.String())
 	}
@@ -88,7 +88,7 @@ func TestInstalledFlagAfterPositional(t *testing.T) {
 	// User-style: subcommand, package, then flag. Must work the same as
 	// flags-first.
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"installed", "vim", "--json", "--no-cache", "--quiet"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"installed", "vim", "--json", "--no-cache", "--quiet"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
 	}
@@ -100,7 +100,7 @@ func TestInstalledFlagAfterPositional(t *testing.T) {
 func TestInstalledHelpExitsZero(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"installed", "--help"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"installed", "--help"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
 	}

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -96,3 +96,12 @@ func TestInstalledFlagAfterPositional(t *testing.T) {
 		t.Errorf("expected JSON envelope on stdout, got %q", out.String())
 	}
 }
+
+func TestInstalledHelpExitsZero(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"installed", "--help"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
+	}
+}

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -82,3 +82,17 @@ func TestInstalledReportsMissingOnStderr(t *testing.T) {
 		t.Errorf("stderr = %q, want substring 'nonexistent'", errOut.String())
 	}
 }
+
+func TestInstalledFlagAfterPositional(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// User-style: subcommand, package, then flag. Must work the same as
+	// flags-first.
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"installed", "vim", "--json", "--no-cache", "--quiet"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("schema")) {
+		t.Errorf("expected JSON envelope on stdout, got %q", out.String())
+	}
+}

--- a/internal/cli/installed_test.go
+++ b/internal/cli/installed_test.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestInstalledAllPresent(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"installed", "--no-cache", "--quiet", "vim", "git"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
+	}
+}
+
+func TestInstalledOneMissing(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"installed", "--no-cache", "--quiet", "vim", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitNegative {
+		t.Fatalf("exit %d, want %d", code, ExitNegative)
+	}
+}
+
+func TestInstalledZeroArgsErrors(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"installed"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+}
+
+func TestInstalledJSONShape(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"installed", "--json", "--no-cache", "--quiet", "vim", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitNegative {
+		t.Fatalf("exit %d", code)
+	}
+	var env struct {
+		Schema int `json:"schema"`
+		Data   []struct {
+			Name      string       `json:"name"`
+			Installed bool         `json:"installed"`
+			Matches   []cliPackage `json:"matches"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody=%s", err, out.String())
+	}
+	if len(env.Data) != 2 {
+		t.Fatalf("data length = %d, want 2", len(env.Data))
+	}
+	if !env.Data[0].Installed || env.Data[0].Name != "vim" {
+		t.Errorf("entry 0 = %+v", env.Data[0])
+	}
+	if env.Data[1].Installed || env.Data[1].Name != "nonexistent" {
+		t.Errorf("entry 1 = %+v", env.Data[1])
+	}
+}
+
+func TestInstalledManagerFilter(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// vim is in pacman; with --manager brew it should be reported as missing.
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"installed", "--manager", "brew", "--no-cache", "--quiet", "vim"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitNegative {
+		t.Errorf("exit %d, want %d", code, ExitNegative)
+	}
+}
+
+func TestInstalledReportsMissingOnStderr(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// Without --quiet, missing packages get listed on stderr.
+	var out, errOut bytes.Buffer
+	_ = Dispatch([]string{"installed", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	if !strings.Contains(errOut.String(), "nonexistent") {
+		t.Errorf("stderr = %q, want substring 'nonexistent'", errOut.String())
+	}
+}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -16,7 +16,7 @@ func init() {
 	subcommands["list"] = runList
 }
 
-func runList(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+func runList(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -42,7 +42,7 @@ func runList(args []string, mgrs []manager.Manager, version string, stdout, stde
 		return ExitErr
 	}
 
-	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	cacheOK := cacheWriteOKFor(*mgrFlag)
 	pkgs, err := collectPackages(filtered, *noCacheFlag, *quietFlag, stderr, cacheOK)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -27,6 +27,7 @@ func runList(args []string, mgrs []manager.Manager, version string, stdout, stde
 	)
 	fs.BoolVar(quietFlag, "q", *quietFlag, "alias for --quiet")
 	fs.StringVar(mgrFlag, "m", *mgrFlag, "alias for --manager")
+	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
 		return ExitErr
 	}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func init() {
+	subcommands["list"] = runList
+}
+
+func runList(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		mgrFlag      = fs.String("manager", "", "comma list of managers (e.g. pacman,aur or !brew); 'all' for all")
+		jsonFlag     = fs.Bool("json", false, "emit JSON envelope")
+		noCacheFlag  = fs.Bool("no-cache", false, "bypass the scan cache; do a fresh live scan")
+		quietFlag    = fs.Bool("quiet", false, "suppress progress messages on stderr")
+		updatesOnly  = fs.Bool("updates-only", false, "only packages whose latest_version differs from version")
+	)
+	fs.BoolVar(quietFlag, "q", *quietFlag, "alias for --quiet")
+	fs.StringVar(mgrFlag, "m", *mgrFlag, "alias for --manager")
+	if err := fs.Parse(args); err != nil {
+		return ExitErr
+	}
+
+	filtered, err := parseManagerFilter(*mgrFlag, mgrs)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitErr
+	}
+
+	pkgs, err := collectPackages(filtered, *noCacheFlag, *quietFlag, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
+		return ExitErr
+	}
+
+	if *updatesOnly {
+		pkgs = withUpdates(filtered, pkgs)
+	}
+
+	sort.Slice(pkgs, func(i, j int) bool { return pkgs[i].Name < pkgs[j].Name })
+
+	if *jsonFlag {
+		if err := writeEnvelope(stdout, version, toCLIPackages(pkgs)); err != nil {
+			fmt.Fprintf(stderr, "error: encoding JSON: %v\n", err)
+			return ExitErr
+		}
+		return ExitOK
+	}
+
+	writeListHuman(stdout, pkgs)
+	return ExitOK
+}
+
+// collectPackages either loads from scan cache or runs a fresh live scan
+// across the filtered manager set, writing back to cache afterward.
+func collectPackages(mgrs []manager.Manager, noCache, quiet bool, stderr io.Writer) ([]model.Package, error) {
+	if !noCache {
+		if cached := manager.LoadScanCache(); cached != nil {
+			// Apply the same manager filter to the cached data so --manager
+			// is honored even on cache hits.
+			return filterByManagers(cached, mgrs), nil
+		}
+	}
+
+	var out []model.Package
+	for _, m := range mgrs {
+		if !m.Available() {
+			continue
+		}
+		if !quiet {
+			fmt.Fprintf(stderr, "scanning %s...\n", m.Name())
+		}
+		pkgs, err := m.Scan()
+		if err != nil {
+			if !quiet {
+				fmt.Fprintf(stderr, "warning: %s scan failed: %v\n", m.Name(), err)
+			}
+			continue
+		}
+		out = append(out, pkgs...)
+	}
+	if !noCache || len(out) > 0 {
+		manager.SaveScanCache(out)
+	}
+	return out, nil
+}
+
+func filterByManagers(pkgs []model.Package, mgrs []manager.Manager) []model.Package {
+	allow := make(map[model.Source]bool, len(mgrs))
+	for _, m := range mgrs {
+		allow[m.Name()] = true
+	}
+	out := pkgs[:0:0]
+	for _, p := range pkgs {
+		if allow[p.Source] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// withUpdates returns only packages whose LatestVersion is set and differs
+// from Version. Lazily fetches updates for managers missing from the cache.
+func withUpdates(mgrs []manager.Manager, pkgs []model.Package) []model.Package {
+	cache := manager.NewUpdateCache()
+	updates := manager.FetchUpdates(mgrs, pkgs, cache)
+	out := make([]model.Package, 0, len(pkgs))
+	for _, p := range pkgs {
+		if latest, ok := updates[p.Key()]; ok && latest != "" && latest != p.Version {
+			p.LatestVersion = latest
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// writeListHuman prints a plain text table: NAME VERSION SOURCE.
+// No ANSI codes; the cli emits plain text whenever stdout isn't a TTY,
+// and tests always run with a bytes.Buffer writer (non-TTY).
+func writeListHuman(w io.Writer, pkgs []model.Package) {
+	if len(pkgs) == 0 {
+		fmt.Fprintln(w, "(no packages)")
+		return
+	}
+	nameW, verW, srcW := 4, 7, 6 // header widths
+	for _, p := range pkgs {
+		if len(p.Name) > nameW {
+			nameW = len(p.Name)
+		}
+		if len(p.Version) > verW {
+			verW = len(p.Version)
+		}
+		if l := len(string(p.Source)); l > srcW {
+			srcW = l
+		}
+	}
+	fmt.Fprintf(w, "%-*s  %-*s  %-*s\n", nameW, "NAME", verW, "VERSION", srcW, "SOURCE")
+	fmt.Fprintln(w, strings.Repeat("-", nameW+verW+srcW+4))
+	for _, p := range pkgs {
+		fmt.Fprintf(w, "%-*s  %-*s  %-*s\n", nameW, p.Name, verW, p.Version, srcW, string(p.Source))
+	}
+}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -29,6 +30,9 @@ func runList(args []string, mgrs []manager.Manager, version string, stdout, stde
 	fs.StringVar(mgrFlag, "m", *mgrFlag, "alias for --manager")
 	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
 		return ExitErr
 	}
 
@@ -38,7 +42,8 @@ func runList(args []string, mgrs []manager.Manager, version string, stdout, stde
 		return ExitErr
 	}
 
-	pkgs, err := collectPackages(filtered, *noCacheFlag, *quietFlag, stderr)
+	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	pkgs, err := collectPackages(filtered, *noCacheFlag, *quietFlag, stderr, cacheOK)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
 		return ExitErr
@@ -64,7 +69,7 @@ func runList(args []string, mgrs []manager.Manager, version string, stdout, stde
 
 // collectPackages either loads from scan cache or runs a fresh live scan
 // across the filtered manager set, writing back to cache afterward.
-func collectPackages(mgrs []manager.Manager, noCache, quiet bool, stderr io.Writer) ([]model.Package, error) {
+func collectPackages(mgrs []manager.Manager, noCache, quiet bool, stderr io.Writer, cacheOK bool) ([]model.Package, error) {
 	if !noCache {
 		if cached := manager.LoadScanCache(); cached != nil {
 			// Apply the same manager filter to the cached data so --manager
@@ -90,7 +95,7 @@ func collectPackages(mgrs []manager.Manager, noCache, quiet bool, stderr io.Writ
 		}
 		out = append(out, pkgs...)
 	}
-	if !noCache || len(out) > 0 {
+	if cacheOK && (!noCache || len(out) > 0) {
 		manager.SaveScanCache(out)
 	}
 	return out, nil

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func mgrSet() []manager.Manager {
+	return []manager.Manager{
+		&fakeManager{
+			name: model.SourcePacman, available: true,
+			scanFn: func() ([]model.Package, error) {
+				return []model.Package{
+					fakePackage("vim", "9.0", model.SourcePacman),
+					fakePackage("git", "2.43", model.SourcePacman),
+				}, nil
+			},
+		},
+		&fakeManager{
+			name: model.SourceBrew, available: true,
+			scanFn: func() ([]model.Package, error) {
+				return []model.Package{
+					fakePackage("ripgrep", "14.0", model.SourceBrew),
+				}, nil
+			},
+		},
+		&fakeManager{
+			name: model.SourceApk, available: false, // not on this system
+		},
+	}
+}
+
+func TestListJSON(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"list", "--json", "--no-cache"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
+	}
+	var env struct {
+		Schema int          `json:"schema"`
+		Data   []cliPackage `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody=%s", err, out.String())
+	}
+	if env.Schema != 1 {
+		t.Errorf("schema = %d, want 1", env.Schema)
+	}
+	if len(env.Data) != 3 {
+		t.Errorf("data length = %d, want 3 (2 pacman + 1 brew)", len(env.Data))
+	}
+}
+
+func TestListJSONFilterByManager(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"list", "--json", "--no-cache", "--manager", "brew"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
+	}
+	var env struct {
+		Data []cliPackage `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(env.Data) != 1 || env.Data[0].Name != "ripgrep" {
+		t.Errorf("data = %+v, want [ripgrep]", env.Data)
+	}
+}
+
+func TestListJSONUnknownManagerErrors(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"list", "--manager", "yum"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout = %q, want empty on error", out.String())
+	}
+	if !strings.Contains(errOut.String(), "unknown manager") {
+		t.Errorf("stderr = %q, want 'unknown manager'", errOut.String())
+	}
+}
+
+func TestListHumanOutput(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"list", "--no-cache"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d", code)
+	}
+	body := out.String()
+	for _, want := range []string{"vim", "git", "ripgrep"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("output missing %q\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "\x1b[") {
+		t.Errorf("output contains ANSI escape codes (writer is not a TTY)")
+	}
+}

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -107,3 +107,43 @@ func TestListHumanOutput(t *testing.T) {
 		t.Errorf("output contains ANSI escape codes (writer is not a TTY)")
 	}
 }
+
+func TestListHelpExitsZero(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"list", "--help"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
+	}
+}
+
+func TestListWithManagerFilterDoesNotOverwriteFullScanCache(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// First call: full scan, populates cache with pacman+brew.
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"list", "--no-cache", "--quiet"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("first call exit %d (stderr=%q)", code, errOut.String())
+	}
+
+	// Second call: --manager pacman --no-cache. MUST NOT overwrite the cache.
+	out.Reset()
+	errOut.Reset()
+	code = Dispatch([]string{"list", "--no-cache", "--quiet", "--manager", "pacman"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("filtered call exit %d (stderr=%q)", code, errOut.String())
+	}
+
+	// Third call: no flags, must hit cache and still see brew packages.
+	out.Reset()
+	errOut.Reset()
+	code = Dispatch([]string{"list", "--quiet"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("third call exit %d (stderr=%q)", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "ripgrep") {
+		t.Errorf("cache poisoned: brew packages dropped. stdout=%q", out.String())
+	}
+}

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -38,7 +38,7 @@ func mgrSet() []manager.Manager {
 func TestListJSON(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"list", "--json", "--no-cache"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"list", "--json", "--no-cache"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
 	}
@@ -60,7 +60,7 @@ func TestListJSON(t *testing.T) {
 func TestListJSONFilterByManager(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"list", "--json", "--no-cache", "--manager", "brew"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"list", "--json", "--no-cache", "--manager", "brew"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
 	}
@@ -78,7 +78,7 @@ func TestListJSONFilterByManager(t *testing.T) {
 func TestListJSONUnknownManagerErrors(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"list", "--manager", "yum"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"list", "--manager", "yum"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitErr {
 		t.Errorf("exit %d, want %d", code, ExitErr)
 	}
@@ -93,7 +93,7 @@ func TestListJSONUnknownManagerErrors(t *testing.T) {
 func TestListHumanOutput(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"list", "--no-cache"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"list", "--no-cache"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d", code)
 	}
@@ -111,7 +111,7 @@ func TestListHumanOutput(t *testing.T) {
 func TestListHelpExitsZero(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"list", "--help"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"list", "--help"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
 	}
@@ -123,7 +123,7 @@ func TestListWithManagerFilterDoesNotOverwriteFullScanCache(t *testing.T) {
 
 	// First call: full scan, populates cache with pacman+brew.
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"list", "--no-cache", "--quiet"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"list", "--no-cache", "--quiet"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("first call exit %d (stderr=%q)", code, errOut.String())
 	}
@@ -131,7 +131,7 @@ func TestListWithManagerFilterDoesNotOverwriteFullScanCache(t *testing.T) {
 	// Second call: --manager pacman --no-cache. MUST NOT overwrite the cache.
 	out.Reset()
 	errOut.Reset()
-	code = Dispatch([]string{"list", "--no-cache", "--quiet", "--manager", "pacman"}, mgrSet(), "test", &out, &errOut)
+	code = Dispatch([]string{"list", "--no-cache", "--quiet", "--manager", "pacman"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("filtered call exit %d (stderr=%q)", code, errOut.String())
 	}
@@ -139,7 +139,7 @@ func TestListWithManagerFilterDoesNotOverwriteFullScanCache(t *testing.T) {
 	// Third call: no flags, must hit cache and still see brew packages.
 	out.Reset()
 	errOut.Reset()
-	code = Dispatch([]string{"list", "--quiet"}, mgrSet(), "test", &out, &errOut)
+	code = Dispatch([]string{"list", "--quiet"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("third call exit %d (stderr=%q)", code, errOut.String())
 	}

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -36,6 +36,7 @@ func mgrSet() []manager.Manager {
 }
 
 func TestListJSON(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
 	code := Dispatch([]string{"list", "--json", "--no-cache"}, mgrSet(), "test", &out, &errOut)
 	if code != ExitOK {
@@ -57,6 +58,7 @@ func TestListJSON(t *testing.T) {
 }
 
 func TestListJSONFilterByManager(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
 	code := Dispatch([]string{"list", "--json", "--no-cache", "--manager", "brew"}, mgrSet(), "test", &out, &errOut)
 	if code != ExitOK {
@@ -74,6 +76,7 @@ func TestListJSONFilterByManager(t *testing.T) {
 }
 
 func TestListJSONUnknownManagerErrors(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
 	code := Dispatch([]string{"list", "--manager", "yum"}, mgrSet(), "test", &out, &errOut)
 	if code != ExitErr {
@@ -88,6 +91,7 @@ func TestListJSONUnknownManagerErrors(t *testing.T) {
 }
 
 func TestListHumanOutput(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
 	code := Dispatch([]string{"list", "--no-cache"}, mgrSet(), "test", &out, &errOut)
 	if code != ExitOK {

--- a/internal/cli/managers.go
+++ b/internal/cli/managers.go
@@ -104,3 +104,12 @@ func knownNames(all []manager.Manager) string {
 	sort.Strings(names)
 	return strings.Join(names, ", ")
 }
+
+// cacheWriteOKFor reports whether a scan that ran under the given --manager
+// filter is safe to write back to the global scan cache. The cache holds every
+// manager's packages; a partial scan would truncate the non-scanned managers'
+// entries for the cache's 10-day TTL. Only the "all managers" forms (empty or
+// "all") preserve the invariant.
+func cacheWriteOKFor(mgrFlag string) bool {
+	return mgrFlag == "" || mgrFlag == "all"
+}

--- a/internal/cli/managers.go
+++ b/internal/cli/managers.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+)
+
+// parseManagerFilter resolves a --manager flag value against the registered
+// manager set. Accepted forms:
+//
+//	""               → all managers (default)
+//	"all"            → all managers (explicit)
+//	"pacman"         → just pacman
+//	"pacman,aur"     → union of named managers
+//	"!brew,!cask"    → everything except the named managers
+//
+// Mixing positive and negative selectors in one filter is an error: it's
+// almost always a mistake by the user. Unknown manager names are also an
+// error; the error message includes the sorted list of known names so the
+// user can see what they typed wrong.
+func parseManagerFilter(value string, all []manager.Manager) ([]manager.Manager, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "all" {
+		return all, nil
+	}
+
+	parts := strings.Split(value, ",")
+	var positive, negative []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if strings.HasPrefix(p, "!") {
+			negative = append(negative, strings.TrimPrefix(p, "!"))
+		} else {
+			positive = append(positive, p)
+		}
+	}
+
+	if len(positive) > 0 && len(negative) > 0 {
+		return nil, fmt.Errorf("--manager: cannot mix positive (%q) and negative (%q) selectors",
+			positive, negative)
+	}
+
+	known := make(map[string]manager.Manager, len(all))
+	for _, m := range all {
+		known[string(m.Name())] = m
+	}
+
+	check := func(name string) error {
+		if _, ok := known[name]; !ok {
+			return fmt.Errorf("--manager: unknown manager %q (known: %s)", name, knownNames(all))
+		}
+		return nil
+	}
+
+	if len(positive) > 0 {
+		var out []manager.Manager
+		seen := make(map[string]bool)
+		for _, name := range positive {
+			if err := check(name); err != nil {
+				return nil, err
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			out = append(out, known[name])
+		}
+		return out, nil
+	}
+
+	// Negation mode: validate names first, then filter.
+	excluded := make(map[string]bool, len(negative))
+	for _, name := range negative {
+		if err := check(name); err != nil {
+			return nil, err
+		}
+		excluded[name] = true
+	}
+	var out []manager.Manager
+	for _, m := range all {
+		if excluded[string(m.Name())] {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+// knownNames returns a sorted, comma-separated string of manager names for
+// error messages. Sorted because error messages get diffed in tests.
+func knownNames(all []manager.Manager) string {
+	names := make([]string, len(all))
+	for i, m := range all {
+		names[i] = string(m.Name())
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}

--- a/internal/cli/managers.go
+++ b/internal/cli/managers.go
@@ -35,7 +35,9 @@ func parseManagerFilter(value string, all []manager.Manager) ([]manager.Manager,
 			continue
 		}
 		if strings.HasPrefix(p, "!") {
-			negative = append(negative, strings.TrimPrefix(p, "!"))
+			// Trim again after stripping "!" so "! pacman" and "!pacman" behave
+			// the same — a space slip-up shouldn't produce a confusing error.
+			negative = append(negative, strings.TrimSpace(strings.TrimPrefix(p, "!")))
 		} else {
 			positive = append(positive, p)
 		}

--- a/internal/cli/managers_test.go
+++ b/internal/cli/managers_test.go
@@ -95,3 +95,17 @@ func TestParseManagerFilter_MixedPositiveAndNegative(t *testing.T) {
 		t.Fatal("expected error mixing positive+negative selectors, got nil")
 	}
 }
+
+func TestParseManagerFilter_NegationWithSpace(t *testing.T) {
+	// "! pacman" (space slipped after the bang) should behave like "!pacman",
+	// not produce a confusing "unknown manager \" pacman\"" error.
+	got, err := parseManagerFilter("! pacman", realMgrs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, m := range got {
+		if string(m.Name()) == "pacman" {
+			t.Errorf("pacman should have been excluded")
+		}
+	}
+}

--- a/internal/cli/managers_test.go
+++ b/internal/cli/managers_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+// realMgrs returns the production manager set for tests that need real names.
+// Tests asserting filter behavior against fakes use the fakes directly.
+func realMgrs() []manager.Manager { return manager.All() }
+
+func sourceSet(mgrs []manager.Manager) []string {
+	out := make([]string, len(mgrs))
+	for i, m := range mgrs {
+		out[i] = string(m.Name())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestParseManagerFilter_Empty(t *testing.T) {
+	got, err := parseManagerFilter("", realMgrs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(realMgrs()) {
+		t.Errorf("empty filter returned %d mgrs, want %d (all)", len(got), len(realMgrs()))
+	}
+}
+
+func TestParseManagerFilter_All(t *testing.T) {
+	got, err := parseManagerFilter("all", realMgrs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(realMgrs()) {
+		t.Errorf("'all' filter returned %d mgrs, want %d", len(got), len(realMgrs()))
+	}
+}
+
+func TestParseManagerFilter_Single(t *testing.T) {
+	got, err := parseManagerFilter("pacman", realMgrs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"pacman"}
+	if diff := sourceSet(got); !reflect.DeepEqual(diff, want) {
+		t.Errorf("got %v, want %v", diff, want)
+	}
+}
+
+func TestParseManagerFilter_CommaList(t *testing.T) {
+	got, err := parseManagerFilter("pacman,aur", realMgrs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"aur", "pacman"}
+	if diff := sourceSet(got); !reflect.DeepEqual(diff, want) {
+		t.Errorf("got %v, want %v", diff, want)
+	}
+}
+
+func TestParseManagerFilter_Negation(t *testing.T) {
+	// '!brew,!brew-cask' means everything except those two.
+	got, err := parseManagerFilter("!brew,!brew-cask", realMgrs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, m := range got {
+		if m.Name() == model.SourceBrew || m.Name() == model.SourceBrewCask {
+			t.Errorf("expected %s to be excluded", m.Name())
+		}
+	}
+	// Should have len(all) - 2 entries.
+	if len(got) != len(realMgrs())-2 {
+		t.Errorf("got %d mgrs, want %d", len(got), len(realMgrs())-2)
+	}
+}
+
+func TestParseManagerFilter_Unknown(t *testing.T) {
+	_, err := parseManagerFilter("yum", realMgrs())
+	if err == nil {
+		t.Fatal("expected error for unknown manager, got nil")
+	}
+}
+
+func TestParseManagerFilter_MixedPositiveAndNegative(t *testing.T) {
+	// Mixing positive and negative selectors is an error — too easy to confuse.
+	_, err := parseManagerFilter("pacman,!brew", realMgrs())
+	if err == nil {
+		t.Fatal("expected error mixing positive+negative selectors, got nil")
+	}
+}

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+)
+
+func init() {
+	subcommands["outdated"] = runOutdated
+}
+
+type outdatedEntry struct {
+	Name    string `json:"name"`
+	Current string `json:"current"`
+	Latest  string `json:"latest"`
+	Source  string `json:"source"`
+}
+
+func runOutdated(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("outdated", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		mgrFlag      = fs.String("manager", "", "comma list of managers (default: all)")
+		countFlag    = fs.Bool("count", false, "emit only the integer count on stdout")
+		exitCodeFlag = fs.Bool("exit-code", false, "exit 2 if any updates available")
+		jsonFlag     = fs.Bool("json", false, "emit JSON envelope")
+		noCacheFlag  = fs.Bool("no-cache", false, "force fresh CheckUpdates")
+		quietFlag    = fs.Bool("quiet", false, "suppress progress on stderr")
+	)
+	fs.BoolVar(quietFlag, "q", false, "alias for --quiet")
+	fs.StringVar(mgrFlag, "m", "", "alias for --manager")
+	if err := fs.Parse(args); err != nil {
+		return ExitErr
+	}
+
+	filtered, err := parseManagerFilter(*mgrFlag, mgrs)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitErr
+	}
+
+	pkgs, err := collectPackages(filtered, *noCacheFlag, *quietFlag, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
+		return ExitErr
+	}
+
+	cache := manager.NewUpdateCache()
+	if *noCacheFlag {
+		// Invalidate cache for the filtered managers so FetchUpdates always
+		// goes to the live source.
+		var keys []string
+		for _, p := range pkgs {
+			keys = append(keys, p.Key())
+		}
+		cache.Invalidate(keys)
+	}
+	updates := manager.FetchUpdates(filtered, pkgs, cache)
+
+	// Build entries. Stable order: by source then name.
+	entries := make([]outdatedEntry, 0, len(updates))
+	for _, p := range pkgs {
+		latest, ok := updates[p.Key()]
+		if !ok || latest == "" || latest == p.Version {
+			continue
+		}
+		entries = append(entries, outdatedEntry{
+			Name:    p.Name,
+			Current: p.Version,
+			Latest:  latest,
+			Source:  string(p.Source),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Source != entries[j].Source {
+			return entries[i].Source < entries[j].Source
+		}
+		return entries[i].Name < entries[j].Name
+	})
+
+	switch {
+	case *countFlag:
+		fmt.Fprintf(stdout, "%d\n", len(entries))
+	case *jsonFlag:
+		// Force [] not null for empty list. encoding/json emits [] for a
+		// non-nil empty slice.
+		if entries == nil {
+			entries = []outdatedEntry{}
+		}
+		if err := writeEnvelope(stdout, version, entries); err != nil {
+			fmt.Fprintf(stderr, "error: encoding JSON: %v\n", err)
+			return ExitErr
+		}
+	default:
+		writeOutdatedHuman(stdout, entries)
+	}
+
+	if *exitCodeFlag && len(entries) > 0 {
+		return ExitNegative
+	}
+	return ExitOK
+}
+
+func writeOutdatedHuman(w io.Writer, entries []outdatedEntry) {
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "(no updates)")
+		return
+	}
+	nameW, srcW := 4, 6
+	for _, e := range entries {
+		if len(e.Name) > nameW {
+			nameW = len(e.Name)
+		}
+		if len(e.Source) > srcW {
+			srcW = len(e.Source)
+		}
+	}
+	fmt.Fprintf(w, "%-*s  %-*s  %s -> %s\n", nameW, "NAME", srcW, "SOURCE", "CURRENT", "LATEST")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-*s  %-*s  %s -> %s\n", nameW, e.Name, srcW, e.Source, e.Current, e.Latest)
+	}
+}

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -21,7 +21,7 @@ type outdatedEntry struct {
 	Source  string `json:"source"`
 }
 
-func runOutdated(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+func runOutdated(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
 	fs := flag.NewFlagSet("outdated", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -48,7 +48,7 @@ func runOutdated(args []string, mgrs []manager.Manager, version string, stdout, 
 		return ExitErr
 	}
 
-	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	cacheOK := cacheWriteOKFor(*mgrFlag)
 	pkgs, err := collectPackages(filtered, *noCacheFlag, *quietFlag, stderr, cacheOK)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -35,6 +36,9 @@ func runOutdated(args []string, mgrs []manager.Manager, version string, stdout, 
 	fs.StringVar(mgrFlag, "m", "", "alias for --manager")
 	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
 		return ExitErr
 	}
 
@@ -44,7 +48,8 @@ func runOutdated(args []string, mgrs []manager.Manager, version string, stdout, 
 		return ExitErr
 	}
 
-	pkgs, err := collectPackages(filtered, *noCacheFlag, *quietFlag, stderr)
+	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	pkgs, err := collectPackages(filtered, *noCacheFlag, *quietFlag, stderr, cacheOK)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
 		return ExitErr

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -33,6 +33,7 @@ func runOutdated(args []string, mgrs []manager.Manager, version string, stdout, 
 	)
 	fs.BoolVar(quietFlag, "q", false, "alias for --quiet")
 	fs.StringVar(mgrFlag, "m", "", "alias for --manager")
+	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
 		return ExitErr
 	}

--- a/internal/cli/outdated_test.go
+++ b/internal/cli/outdated_test.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func mgrSetWithUpdates() []manager.Manager {
+	return []manager.Manager{
+		&fakeManager{
+			name: model.SourcePacman, available: true,
+			scanFn: func() ([]model.Package, error) {
+				return []model.Package{
+					fakePackage("vim", "9.0", model.SourcePacman),
+					fakePackage("git", "2.43", model.SourcePacman),
+				}, nil
+			},
+			checkUpdatesFn: func(pkgs []model.Package) map[string]string {
+				return map[string]string{"vim": "9.1"}
+			},
+		},
+	}
+}
+
+func mgrSetNoUpdates() []manager.Manager {
+	return []manager.Manager{
+		&fakeManager{
+			name: model.SourcePacman, available: true,
+			scanFn: func() ([]model.Package, error) {
+				return []model.Package{fakePackage("vim", "9.0", model.SourcePacman)}, nil
+			},
+			checkUpdatesFn: func(pkgs []model.Package) map[string]string { return nil },
+		},
+	}
+}
+
+func TestOutdatedCountFormat(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"outdated", "--count", "--no-cache"}, mgrSetWithUpdates(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
+	}
+	if !regexp.MustCompile(`^[0-9]+\n$`).MatchString(out.String()) {
+		t.Errorf("--count output = %q, want /^[0-9]+\\n$/", out.String())
+	}
+	if strings.TrimSpace(out.String()) != "1" {
+		t.Errorf("count = %q, want '1'", strings.TrimSpace(out.String()))
+	}
+}
+
+func TestOutdatedCountZero(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"outdated", "--count", "--no-cache"}, mgrSetNoUpdates(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d", code)
+	}
+	if strings.TrimSpace(out.String()) != "0" {
+		t.Errorf("count = %q, want '0'", strings.TrimSpace(out.String()))
+	}
+}
+
+func TestOutdatedExitCodeWithUpdates(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"outdated", "--exit-code", "--no-cache"}, mgrSetWithUpdates(), "test", &out, &errOut)
+	if code != ExitNegative {
+		t.Errorf("exit %d, want %d", code, ExitNegative)
+	}
+}
+
+func TestOutdatedExitCodeNoUpdates(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"outdated", "--exit-code", "--no-cache"}, mgrSetNoUpdates(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Errorf("exit %d, want %d", code, ExitOK)
+	}
+}
+
+func TestOutdatedJSON(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"outdated", "--json", "--no-cache"}, mgrSetWithUpdates(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d", code)
+	}
+	var env struct {
+		Schema int `json:"schema"`
+		Data   []struct {
+			Name    string `json:"name"`
+			Current string `json:"current"`
+			Latest  string `json:"latest"`
+			Source  string `json:"source"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if env.Schema != 1 {
+		t.Errorf("schema = %d", env.Schema)
+	}
+	if len(env.Data) != 1 {
+		t.Fatalf("data length = %d, want 1", len(env.Data))
+	}
+	e := env.Data[0]
+	if e.Name != "vim" || e.Current != "9.0" || e.Latest != "9.1" || e.Source != "pacman" {
+		t.Errorf("entry = %+v", e)
+	}
+}
+
+func TestOutdatedJSONEmptyIsEmptyArray(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"outdated", "--json", "--no-cache"}, mgrSetNoUpdates(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d", code)
+	}
+	// data must be [] not null, even when empty
+	if !strings.Contains(out.String(), `"data":[]`) {
+		t.Errorf("empty data should serialize as [], got: %s", out.String())
+	}
+}

--- a/internal/cli/outdated_test.go
+++ b/internal/cli/outdated_test.go
@@ -128,3 +128,12 @@ func TestOutdatedJSONEmptyIsEmptyArray(t *testing.T) {
 		t.Errorf("empty data should serialize as [], got: %s", out.String())
 	}
 }
+
+func TestOutdatedHelpExitsZero(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"outdated", "--help"}, mgrSetNoUpdates(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
+	}
+}

--- a/internal/cli/outdated_test.go
+++ b/internal/cli/outdated_test.go
@@ -43,7 +43,7 @@ func mgrSetNoUpdates() []manager.Manager {
 func TestOutdatedCountFormat(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"outdated", "--count", "--no-cache"}, mgrSetWithUpdates(), "test", &out, &errOut)
+	code := Dispatch([]string{"outdated", "--count", "--no-cache"}, mgrSetWithUpdates(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
 	}
@@ -58,7 +58,7 @@ func TestOutdatedCountFormat(t *testing.T) {
 func TestOutdatedCountZero(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"outdated", "--count", "--no-cache"}, mgrSetNoUpdates(), "test", &out, &errOut)
+	code := Dispatch([]string{"outdated", "--count", "--no-cache"}, mgrSetNoUpdates(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d", code)
 	}
@@ -70,7 +70,7 @@ func TestOutdatedCountZero(t *testing.T) {
 func TestOutdatedExitCodeWithUpdates(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"outdated", "--exit-code", "--no-cache"}, mgrSetWithUpdates(), "test", &out, &errOut)
+	code := Dispatch([]string{"outdated", "--exit-code", "--no-cache"}, mgrSetWithUpdates(), "test", &out, &errOut, nil)
 	if code != ExitNegative {
 		t.Errorf("exit %d, want %d", code, ExitNegative)
 	}
@@ -79,7 +79,7 @@ func TestOutdatedExitCodeWithUpdates(t *testing.T) {
 func TestOutdatedExitCodeNoUpdates(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"outdated", "--exit-code", "--no-cache"}, mgrSetNoUpdates(), "test", &out, &errOut)
+	code := Dispatch([]string{"outdated", "--exit-code", "--no-cache"}, mgrSetNoUpdates(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Errorf("exit %d, want %d", code, ExitOK)
 	}
@@ -88,7 +88,7 @@ func TestOutdatedExitCodeNoUpdates(t *testing.T) {
 func TestOutdatedJSON(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"outdated", "--json", "--no-cache"}, mgrSetWithUpdates(), "test", &out, &errOut)
+	code := Dispatch([]string{"outdated", "--json", "--no-cache"}, mgrSetWithUpdates(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d", code)
 	}
@@ -119,7 +119,7 @@ func TestOutdatedJSON(t *testing.T) {
 func TestOutdatedJSONEmptyIsEmptyArray(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"outdated", "--json", "--no-cache"}, mgrSetNoUpdates(), "test", &out, &errOut)
+	code := Dispatch([]string{"outdated", "--json", "--no-cache"}, mgrSetNoUpdates(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d", code)
 	}
@@ -132,7 +132,7 @@ func TestOutdatedJSONEmptyIsEmptyArray(t *testing.T) {
 func TestOutdatedHelpExitsZero(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"outdated", "--help"}, mgrSetNoUpdates(), "test", &out, &errOut)
+	code := Dispatch([]string{"outdated", "--help"}, mgrSetNoUpdates(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
 	}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/mattn/go-isatty"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+// SchemaVersion is bumped only on non-additive JSON changes.
+// Additive fields (new keys with omitempty) keep schema=1.
+const SchemaVersion = 1
+
+// envelope is the top-level shape of every --json output.
+type envelope struct {
+	GpkVersion string      `json:"gpk_version"`
+	Schema     int         `json:"schema"`
+	Data       interface{} `json:"data"`
+}
+
+// writeEnvelope serializes the envelope to w and appends a trailing newline.
+// Always uses compact (non-indented) JSON.
+func writeEnvelope(w io.Writer, version string, data interface{}) error {
+	env := envelope{
+		GpkVersion: version,
+		Schema:     SchemaVersion,
+		Data:       data,
+	}
+	enc := json.NewEncoder(w)
+	return enc.Encode(env)
+}
+
+// cliPackage is the JSON DTO for a package emitted by the cli. It differs
+// from model.Package only by including LatestVersion (which model.Package
+// hides with json:"-" so it doesn't leak into snapshot files).
+type cliPackage struct {
+	Name          string       `json:"name"`
+	Version       string       `json:"version"`
+	Source        model.Source `json:"source"`
+	Description   string       `json:"description,omitempty"`
+	Size          string       `json:"size,omitempty"`
+	SizeBytes     int64        `json:"size_bytes,omitempty"`
+	Repository    string       `json:"repository,omitempty"`
+	DependsOn     []string     `json:"depends_on,omitempty"`
+	RequiredBy    []string     `json:"required_by,omitempty"`
+	InstalledAt   time.Time    `json:"installed_at"`
+	LatestVersion string       `json:"latest_version,omitempty"`
+}
+
+func toCLIPackage(p model.Package) cliPackage {
+	return cliPackage{
+		Name:          p.Name,
+		Version:       p.Version,
+		Source:        p.Source,
+		Description:   p.Description,
+		Size:          p.Size,
+		SizeBytes:     p.SizeBytes,
+		Repository:    p.Repository,
+		DependsOn:     p.DependsOn,
+		RequiredBy:    p.RequiredBy,
+		InstalledAt:   p.InstalledAt,
+		LatestVersion: p.LatestVersion,
+	}
+}
+
+func toCLIPackages(ps []model.Package) []cliPackage {
+	out := make([]cliPackage, len(ps))
+	for i, p := range ps {
+		out[i] = toCLIPackage(p)
+	}
+	return out
+}
+
+// ansiRegex matches ANSI CSI escape sequences (color codes, cursor moves).
+// Used by stripANSI for non-TTY human output.
+var ansiRegex = regexp.MustCompile("\x1b\\[[0-9;]*[a-zA-Z]")
+
+func stripANSI(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
+// isStdoutTTY reports whether os.Stdout is connected to a real terminal.
+// Tests use a bytes.Buffer (not a TTY), so this always returns false in tests.
+func isStdoutTTY() bool {
+	return isatty.IsTerminal(os.Stdout.Fd())
+}

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func TestEnvelopeSchema(t *testing.T) {
+	var buf bytes.Buffer
+	err := writeEnvelope(&buf, "0.6.4", []int{1, 2, 3})
+	if err != nil {
+		t.Fatalf("writeEnvelope: %v", err)
+	}
+	var got struct {
+		GpkVersion string `json:"gpk_version"`
+		Schema     int    `json:"schema"`
+		Data       []int  `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Schema != 1 {
+		t.Errorf("schema = %d, want 1", got.Schema)
+	}
+	if got.GpkVersion != "0.6.4" {
+		t.Errorf("gpk_version = %q, want %q", got.GpkVersion, "0.6.4")
+	}
+	if len(got.Data) != 3 {
+		t.Errorf("data length = %d, want 3", len(got.Data))
+	}
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Error("envelope output missing trailing newline")
+	}
+}
+
+func TestToCLIPackageCopiesLatestVersion(t *testing.T) {
+	p := model.Package{
+		Name:          "foo",
+		Version:       "1.0",
+		Source:        model.SourcePacman,
+		LatestVersion: "1.1",
+		InstalledAt:   time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC),
+	}
+	c := toCLIPackage(p)
+	if c.LatestVersion != "1.1" {
+		t.Errorf("LatestVersion = %q, want %q", c.LatestVersion, "1.1")
+	}
+	if c.Name != "foo" || c.Version != "1.0" || c.Source != model.SourcePacman {
+		t.Errorf("field copy wrong: %+v", c)
+	}
+}
+
+func TestCLIPackageJSONIncludesLatestVersion(t *testing.T) {
+	c := toCLIPackage(model.Package{
+		Name:          "foo",
+		Version:       "1.0",
+		Source:        model.SourceBrew,
+		LatestVersion: "1.1",
+		InstalledAt:   time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC),
+	})
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"latest_version":"1.1"`) {
+		t.Errorf("JSON missing latest_version: %s", data)
+	}
+}
+
+func TestCLIPackageJSONOmitsEmptyLatestVersion(t *testing.T) {
+	c := toCLIPackage(model.Package{
+		Name:        "foo",
+		Version:     "1.0",
+		Source:      model.SourceBrew,
+		InstalledAt: time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC),
+	})
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "latest_version") {
+		t.Errorf("JSON should omit empty latest_version: %s", data)
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"plain", "plain"},
+		{"\x1b[31mred\x1b[0m", "red"},
+		{"a\x1b[1;32mb\x1b[0mc", "abc"},
+	}
+	for _, c := range cases {
+		got := stripANSI(c.in)
+		if got != c.want {
+			t.Errorf("stripANSI(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func init() {
+	subcommands["remove"] = runRemove
+}
+
+func runRemove(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
+	args = reorderFlagsFirst(args, []string{"manager", "m"})
+	fs := flag.NewFlagSet("remove", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		mgrFlag      = fs.String("manager", "", "manager to remove from; required if package is installed in multiple")
+		withDepsFlag = fs.Bool("with-deps", false, "also remove orphaned dependencies (pacman, apt, dnf, xbps)")
+		yesFlag      = fs.Bool("yes", false, "skip the y/N confirmation prompt")
+		dryRunFlag   = fs.Bool("dry-run", false, "print the command(s) without executing")
+		quietFlag    = fs.Bool("quiet", false, "suppress progress on stderr")
+	)
+	fs.BoolVar(yesFlag, "y", false, "alias for --yes")
+	fs.BoolVar(quietFlag, "q", false, "alias for --quiet")
+	fs.StringVar(mgrFlag, "m", "", "alias for --manager")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
+		return ExitErr
+	}
+
+	names := fs.Args()
+	if len(names) == 0 {
+		fmt.Fprintln(stderr, "error: remove requires at least one package name")
+		return ExitErr
+	}
+
+	filtered, err := parseManagerFilter(*mgrFlag, mgrs)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitErr
+	}
+
+	// Scan to find which installed manager owns each name.
+	pkgs, err := collectPackages(filtered, false, true, stderr, false /* never cache during write */)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
+		return ExitErr
+	}
+
+	type plan struct {
+		pkg     model.Package
+		mgr     manager.Manager
+		remover manager.Remover
+		cmdStr  string
+		warning string
+	}
+	var plans []plan
+	for _, name := range names {
+		var matches []model.Package
+		for _, p := range pkgs {
+			if p.Name == name {
+				matches = append(matches, p)
+			}
+		}
+		if len(matches) == 0 {
+			fmt.Fprintf(stderr, "error: %q is not installed in any searched manager\n", name)
+			return ExitNegative
+		}
+		if len(matches) > 1 {
+			var srcs []string
+			for _, m := range matches {
+				srcs = append(srcs, string(m.Source))
+			}
+			fmt.Fprintf(stderr, "error: %q installed in %d managers (%s); use --manager to pick\n",
+				name, len(matches), strings.Join(srcs, ", "))
+			return ExitAmbiguous
+		}
+		pkg := matches[0]
+		mgr := mgrByName(filtered, pkg.Source)
+		if mgr == nil {
+			fmt.Fprintf(stderr, "error: manager %s not in filtered set\n", pkg.Source)
+			return ExitErr
+		}
+		remover, ok := mgr.(manager.Remover)
+		if !ok {
+			fmt.Fprintf(stderr, "error: %s does not support remove\n", mgr.Name())
+			return ExitErr
+		}
+
+		var cmd *exec.Cmd
+		if *withDepsFlag {
+			deep, ok := mgr.(manager.DeepRemover)
+			if !ok {
+				fmt.Fprintf(stderr, "error: %s does not support --with-deps\n", mgr.Name())
+				return ExitErr
+			}
+			cmd = deep.RemoveCmdWithDeps(name)
+		} else {
+			cmd = remover.RemoveCmd(name)
+		}
+
+		cmdDisplay := strings.Join(stripSudoStdinFlag(cmd).Args, " ")
+
+		warning := ""
+		if len(pkg.RequiredBy) > 0 {
+			req := strings.Join(pkg.RequiredBy, ", ")
+			if len(req) > 60 {
+				req = req[:60] + "..."
+			}
+			warning = "  ⚠ required by: " + req
+		}
+
+		plans = append(plans, plan{pkg: pkg, mgr: mgr, remover: remover, cmdStr: cmdDisplay, warning: warning})
+	}
+
+	// Print plan and prompt.
+	fmt.Fprintln(stdout, "The following commands will run:")
+	for _, p := range plans {
+		fmt.Fprintf(stdout, "  %s  →  %s\n", p.mgr.Name(), p.cmdStr)
+		if p.warning != "" {
+			fmt.Fprintln(stdout, p.warning)
+		}
+	}
+
+	if *dryRunFlag {
+		fmt.Fprintln(stdout, "(dry-run; nothing executed)")
+		return ExitOK
+	}
+
+	if !*yesFlag {
+		if !confirmAction("Proceed? [y/N] ", stdin, stdout) {
+			fmt.Fprintln(stderr, "cancelled")
+			return ExitOK
+		}
+	}
+
+	// Execute. Stop on first failure.
+	for _, p := range plans {
+		if !*quietFlag {
+			fmt.Fprintf(stderr, "removing %s via %s...\n", p.pkg.Name, p.mgr.Name())
+		}
+		var c *exec.Cmd
+		if *withDepsFlag {
+			c = p.mgr.(manager.DeepRemover).RemoveCmdWithDeps(p.pkg.Name)
+		} else {
+			c = p.remover.RemoveCmd(p.pkg.Name)
+		}
+		if err := headlessExec(c); err != nil {
+			fmt.Fprintf(stderr, "error: remove %s failed: %v\n", p.pkg.Name, err)
+			return ExitErr
+		}
+		invalidateAfterWrite(p.mgr, []model.Package{p.pkg})
+	}
+	return ExitOK
+}
+
+// mgrByName finds a manager by its Source name within a filtered set.
+func mgrByName(filtered []manager.Manager, src model.Source) manager.Manager {
+	for _, m := range filtered {
+		if m.Name() == src {
+			return m
+		}
+	}
+	return nil
+}

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -104,9 +104,32 @@ func runRemove(args []string, mgrs []manager.Manager, version string, stdout, st
 				fmt.Fprintf(stderr, "error: %s does not support --with-deps\n", mgr.Name())
 				return ExitErr
 			}
-			cmd = deep.RemoveCmdWithDeps(name)
+			if *yesFlag {
+				if ni, ok := mgr.(manager.NonInteractiveDeepRemover); ok {
+					cmd = ni.RemoveCmdWithDepsYes(name)
+				}
+			}
+			if cmd == nil {
+				cmd = deep.RemoveCmdWithDeps(name)
+			}
 		} else {
-			cmd = remover.RemoveCmd(name)
+			if *yesFlag {
+				if ni, ok := mgr.(manager.NonInteractiveRemover); ok {
+					cmd = ni.RemoveCmdYes(name)
+				}
+			}
+			if cmd == nil {
+				cmd = remover.RemoveCmd(name)
+			}
+		}
+
+		if cmd == nil {
+			if *withDepsFlag {
+				fmt.Fprintf(stderr, "error: %s does not support --with-deps for %q\n", mgr.Name(), name)
+			} else {
+				fmt.Fprintf(stderr, "error: %s returned no remove command for %q\n", mgr.Name(), name)
+			}
+			return ExitErr
 		}
 
 		cmdDisplay := strings.Join(stripSudoStdinFlag(cmd).Args, " ")
@@ -151,9 +174,23 @@ func runRemove(args []string, mgrs []manager.Manager, version string, stdout, st
 		}
 		var c *exec.Cmd
 		if *withDepsFlag {
-			c = p.mgr.(manager.DeepRemover).RemoveCmdWithDeps(p.pkg.Name)
+			if *yesFlag {
+				if ni, ok := p.mgr.(manager.NonInteractiveDeepRemover); ok {
+					c = ni.RemoveCmdWithDepsYes(p.pkg.Name)
+				}
+			}
+			if c == nil {
+				c = p.mgr.(manager.DeepRemover).RemoveCmdWithDeps(p.pkg.Name)
+			}
 		} else {
-			c = p.remover.RemoveCmd(p.pkg.Name)
+			if *yesFlag {
+				if ni, ok := p.mgr.(manager.NonInteractiveRemover); ok {
+					c = ni.RemoveCmdYes(p.pkg.Name)
+				}
+			}
+			if c == nil {
+				c = p.remover.RemoveCmd(p.pkg.Name)
+			}
 		}
 		if err := headlessExec(c); err != nil {
 			fmt.Fprintf(stderr, "error: remove %s failed: %v\n", p.pkg.Name, err)

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -26,6 +26,7 @@ func runRemove(args []string, mgrs []manager.Manager, version string, stdout, st
 		yesFlag      = fs.Bool("yes", false, "skip the y/N confirmation prompt")
 		dryRunFlag   = fs.Bool("dry-run", false, "print the command(s) without executing")
 		quietFlag    = fs.Bool("quiet", false, "suppress progress on stderr")
+		noCacheFlag  = fs.Bool("no-cache", false, "bypass the scan cache; do a fresh live scan")
 	)
 	fs.BoolVar(yesFlag, "y", false, "alias for --yes")
 	fs.BoolVar(quietFlag, "q", false, "alias for --quiet")
@@ -50,7 +51,7 @@ func runRemove(args []string, mgrs []manager.Manager, version string, stdout, st
 	}
 
 	// Scan to find which installed manager owns each name.
-	pkgs, err := collectPackages(filtered, false, true, stderr, false /* never cache during write */)
+	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr, false)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
 		return ExitErr

--- a/internal/cli/remove_test.go
+++ b/internal/cli/remove_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func removeFakeMgrs() []manager.Manager {
+	return []manager.Manager{
+		&fakeManager{
+			name: model.SourcePacman, available: true,
+			scanFn: func() ([]model.Package, error) {
+				return []model.Package{
+					fakePackage("git", "2.43", model.SourcePacman),
+					fakePackage("hello", "1.0", model.SourcePacman),
+				}, nil
+			},
+			removeCmdFn: func(name string) *exec.Cmd {
+				return exec.Command("/bin/true", "remove", name)
+			},
+		},
+		&fakeManager{
+			name: model.SourceBrew, available: true,
+			scanFn: func() ([]model.Package, error) {
+				return []model.Package{fakePackage("git", "2.43", model.SourceBrew)}, nil
+			},
+			removeCmdFn: func(name string) *exec.Cmd {
+				return exec.Command("/bin/true", "uninstall", name)
+			},
+		},
+	}
+}
+
+func TestRemoveNoArgs(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"remove"}, removeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+}
+
+func TestRemoveNotInstalled(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"remove", "nonexistent", "--yes", "--quiet"}, removeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitNegative {
+		t.Errorf("exit %d, want %d", code, ExitNegative)
+	}
+}
+
+func TestRemoveAmbiguous(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// git is installed in both pacman and brew.
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"remove", "git", "--yes", "--quiet"}, removeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitAmbiguous {
+		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitAmbiguous, errOut.String())
+	}
+}
+
+func TestRemoveExplicitManagerYes(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"remove", "git", "--manager", "brew", "--yes", "--quiet"}, removeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Fatalf("exit %d, stderr=%q", code, errOut.String())
+	}
+}
+
+func TestRemoveDryRun(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"remove", "hello", "--dry-run"}, removeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Fatalf("exit %d", code)
+	}
+	if !strings.Contains(out.String(), "dry-run") {
+		t.Errorf("dry-run notice missing: %q", out.String())
+	}
+}
+
+func TestRemovePromptNo(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	stdin := strings.NewReader("n\n")
+	code := Dispatch([]string{"remove", "hello"}, removeFakeMgrs(), "test", &out, &errOut, stdin)
+	if code != ExitOK {
+		t.Fatalf("cancellation exit %d", code)
+	}
+	if !strings.Contains(errOut.String(), "cancelled") {
+		t.Errorf("expected 'cancelled': %q", errOut.String())
+	}
+}
+
+func TestRemoveWithDepsUnsupported(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// fakeManager doesn't implement DeepRemover (no removeCmdWithDepsFn field).
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"remove", "hello", "--with-deps", "--manager", "pacman", "--yes", "--quiet"}, removeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+	if !strings.Contains(errOut.String(), "with-deps") && !strings.Contains(errOut.String(), "does not support") {
+		t.Errorf("expected --with-deps error: %q", errOut.String())
+	}
+}
+
+func TestRemoveHelpExitsZero(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"remove", "--help"}, removeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Errorf("exit %d, want %d", code, ExitOK)
+	}
+}
+
+func TestRemoveRequiredByWarning(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	pacman := &fakeManager{
+		name: model.SourcePacman, available: true,
+		scanFn: func() ([]model.Package, error) {
+			p := fakePackage("foo", "1.0", model.SourcePacman)
+			p.RequiredBy = []string{"bar", "baz"}
+			return []model.Package{p}, nil
+		},
+		removeCmdFn: func(name string) *exec.Cmd {
+			return exec.Command("/bin/true", name)
+		},
+	}
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"remove", "foo", "--dry-run"}, []manager.Manager{pacman}, "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Fatalf("exit %d", code)
+	}
+	if !strings.Contains(out.String(), "required by") {
+		t.Errorf("expected required-by warning in stdout: %q", out.String())
+	}
+}

--- a/internal/cli/source_of.go
+++ b/internal/cli/source_of.go
@@ -23,6 +23,7 @@ func runSourceOf(args []string, mgrs []manager.Manager, version string, stdout, 
 		noCacheFlag = fs.Bool("no-cache", false, "bypass the scan cache")
 	)
 	fs.StringVar(mgrFlag, "m", "", "alias for --manager")
+	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
 		return ExitErr
 	}

--- a/internal/cli/source_of.go
+++ b/internal/cli/source_of.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func init() {
+	subcommands["source-of"] = runSourceOf
+}
+
+func runSourceOf(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("source-of", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		mgrFlag     = fs.String("manager", "", "comma list of managers (default: all)")
+		allFlag     = fs.Bool("all", false, "list every source that has the package")
+		jsonFlag    = fs.Bool("json", false, "emit JSON envelope")
+		noCacheFlag = fs.Bool("no-cache", false, "bypass the scan cache")
+	)
+	fs.StringVar(mgrFlag, "m", "", "alias for --manager")
+	if err := fs.Parse(args); err != nil {
+		return ExitErr
+	}
+
+	rest := fs.Args()
+	if len(rest) != 1 {
+		fmt.Fprintln(stderr, "error: source-of takes exactly one package name")
+		return ExitErr
+	}
+	name := rest[0]
+
+	filtered, err := parseManagerFilter(*mgrFlag, mgrs)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitErr
+	}
+
+	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
+		return ExitErr
+	}
+
+	var sources []string
+	seen := make(map[model.Source]bool)
+	// Iterate in filtered (manager.All()) order so output is stable.
+	for _, m := range filtered {
+		for _, p := range pkgs {
+			if p.Name == name && p.Source == m.Name() && !seen[p.Source] {
+				seen[p.Source] = true
+				sources = append(sources, string(p.Source))
+				break
+			}
+		}
+	}
+
+	if len(sources) == 0 {
+		return ExitNegative
+	}
+	if !*allFlag {
+		sources = sources[:1]
+	}
+
+	if *jsonFlag {
+		data := struct {
+			Name    string   `json:"name"`
+			Sources []string `json:"sources"`
+		}{Name: name, Sources: sources}
+		if err := writeEnvelope(stdout, version, data); err != nil {
+			fmt.Fprintf(stderr, "error: encoding JSON: %v\n", err)
+			return ExitErr
+		}
+		return ExitOK
+	}
+	for _, s := range sources {
+		fmt.Fprintln(stdout, s)
+	}
+	return ExitOK
+}

--- a/internal/cli/source_of.go
+++ b/internal/cli/source_of.go
@@ -14,7 +14,7 @@ func init() {
 	subcommands["source-of"] = runSourceOf
 }
 
-func runSourceOf(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer) int {
+func runSourceOf(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
 	fs := flag.NewFlagSet("source-of", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (

--- a/internal/cli/source_of.go
+++ b/internal/cli/source_of.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -25,6 +26,9 @@ func runSourceOf(args []string, mgrs []manager.Manager, version string, stdout, 
 	fs.StringVar(mgrFlag, "m", "", "alias for --manager")
 	args = reorderFlagsFirst(args, []string{"manager", "m"})
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
 		return ExitErr
 	}
 
@@ -41,7 +45,8 @@ func runSourceOf(args []string, mgrs []manager.Manager, version string, stdout, 
 		return ExitErr
 	}
 
-	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr)
+	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr, cacheOK)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
 		return ExitErr

--- a/internal/cli/source_of.go
+++ b/internal/cli/source_of.go
@@ -45,7 +45,7 @@ func runSourceOf(args []string, mgrs []manager.Manager, version string, stdout, 
 		return ExitErr
 	}
 
-	cacheOK := *mgrFlag == "" || *mgrFlag == "all"
+	cacheOK := cacheWriteOKFor(*mgrFlag)
 	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr, cacheOK)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)

--- a/internal/cli/source_of_test.go
+++ b/internal/cli/source_of_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSourceOfFound(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"source-of", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
+	}
+	if strings.TrimSpace(out.String()) != "pacman" {
+		t.Errorf("stdout = %q, want 'pacman'", out.String())
+	}
+}
+
+func TestSourceOfNotFound(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"source-of", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitNegative {
+		t.Errorf("exit %d, want %d", code, ExitNegative)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout = %q, want empty", out.String())
+	}
+}
+
+func TestSourceOfMissingArg(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"source-of"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+}
+
+func TestSourceOfTooManyArgs(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"source-of", "vim", "git"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+}
+
+func TestSourceOfJSONFound(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"source-of", "--json", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Fatalf("exit %d", code)
+	}
+	var env struct {
+		Data struct {
+			Name    string   `json:"name"`
+			Sources []string `json:"sources"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if env.Data.Name != "vim" || len(env.Data.Sources) != 1 || env.Data.Sources[0] != "pacman" {
+		t.Errorf("data = %+v", env.Data)
+	}
+}
+
+func TestSourceOfJSONNotFoundEmitsNothing(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"source-of", "--json", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitNegative {
+		t.Fatalf("exit %d", code)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout should be empty on exit 2, got %q", out.String())
+	}
+}

--- a/internal/cli/source_of_test.go
+++ b/internal/cli/source_of_test.go
@@ -81,3 +81,12 @@ func TestSourceOfJSONNotFoundEmitsNothing(t *testing.T) {
 		t.Errorf("stdout should be empty on exit 2, got %q", out.String())
 	}
 }
+
+func TestSourceOfHelpExitsZero(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"source-of", "--help"}, mgrSet(), "test", &out, &errOut)
+	if code != ExitOK {
+		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
+	}
+}

--- a/internal/cli/source_of_test.go
+++ b/internal/cli/source_of_test.go
@@ -10,7 +10,7 @@ import (
 func TestSourceOfFound(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"source-of", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"source-of", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d (stderr=%q)", code, errOut.String())
 	}
@@ -22,7 +22,7 @@ func TestSourceOfFound(t *testing.T) {
 func TestSourceOfNotFound(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"source-of", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"source-of", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitNegative {
 		t.Errorf("exit %d, want %d", code, ExitNegative)
 	}
@@ -34,7 +34,7 @@ func TestSourceOfNotFound(t *testing.T) {
 func TestSourceOfMissingArg(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"source-of"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"source-of"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitErr {
 		t.Errorf("exit %d, want %d", code, ExitErr)
 	}
@@ -43,7 +43,7 @@ func TestSourceOfMissingArg(t *testing.T) {
 func TestSourceOfTooManyArgs(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"source-of", "vim", "git"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"source-of", "vim", "git"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitErr {
 		t.Errorf("exit %d, want %d", code, ExitErr)
 	}
@@ -52,7 +52,7 @@ func TestSourceOfTooManyArgs(t *testing.T) {
 func TestSourceOfJSONFound(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"source-of", "--json", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"source-of", "--json", "--no-cache", "vim"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Fatalf("exit %d", code)
 	}
@@ -73,7 +73,7 @@ func TestSourceOfJSONFound(t *testing.T) {
 func TestSourceOfJSONNotFoundEmitsNothing(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"source-of", "--json", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"source-of", "--json", "--no-cache", "nonexistent"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitNegative {
 		t.Fatalf("exit %d", code)
 	}
@@ -85,7 +85,7 @@ func TestSourceOfJSONNotFoundEmitsNothing(t *testing.T) {
 func TestSourceOfHelpExitsZero(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	var out, errOut bytes.Buffer
-	code := Dispatch([]string{"source-of", "--help"}, mgrSet(), "test", &out, &errOut)
+	code := Dispatch([]string{"source-of", "--help"}, mgrSet(), "test", &out, &errOut, nil)
 	if code != ExitOK {
 		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitOK, errOut.String())
 	}

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func init() {
+	subcommands["upgrade"] = runUpgrade
+}
+
+func runUpgrade(args []string, mgrs []manager.Manager, version string, stdout, stderr io.Writer, stdin io.Reader) int {
+	args = reorderFlagsFirst(args, []string{"manager", "m"})
+	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		mgrFlag    = fs.String("manager", "", "manager to upgrade from; required if package is installed in multiple")
+		yesFlag    = fs.Bool("yes", false, "skip the y/N confirmation prompt")
+		dryRunFlag = fs.Bool("dry-run", false, "print the command(s) without executing")
+		quietFlag  = fs.Bool("quiet", false, "suppress progress on stderr")
+	)
+	fs.BoolVar(yesFlag, "y", false, "alias for --yes")
+	fs.BoolVar(quietFlag, "q", false, "alias for --quiet")
+	fs.StringVar(mgrFlag, "m", "", "alias for --manager")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
+		return ExitErr
+	}
+
+	names := fs.Args()
+	if len(names) == 0 {
+		fmt.Fprintln(stderr, "error: upgrade requires at least one package name")
+		return ExitErr
+	}
+
+	filtered, err := parseManagerFilter(*mgrFlag, mgrs)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitErr
+	}
+
+	pkgs, err := collectPackages(filtered, false, true, stderr, false)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
+		return ExitErr
+	}
+
+	type plan struct {
+		pkg      model.Package
+		mgr      manager.Manager
+		upgrader manager.Upgrader
+		cmd      *exec.Cmd
+		cmdStr   string
+	}
+	var plans []plan
+	for _, name := range names {
+		var matches []model.Package
+		for _, p := range pkgs {
+			if p.Name == name {
+				matches = append(matches, p)
+			}
+		}
+		if len(matches) == 0 {
+			fmt.Fprintf(stderr, "error: %q is not installed in any searched manager\n", name)
+			return ExitNegative
+		}
+		if len(matches) > 1 {
+			var srcs []string
+			for _, m := range matches {
+				srcs = append(srcs, string(m.Source))
+			}
+			fmt.Fprintf(stderr, "error: %q installed in %d managers (%s); use --manager to pick\n",
+				name, len(matches), strings.Join(srcs, ", "))
+			return ExitAmbiguous
+		}
+		pkg := matches[0]
+		mgr := mgrByName(filtered, pkg.Source)
+		if mgr == nil {
+			fmt.Fprintf(stderr, "error: manager %s not in filtered set\n", pkg.Source)
+			return ExitErr
+		}
+		upgrader, ok := mgr.(manager.Upgrader)
+		if !ok {
+			fmt.Fprintf(stderr, "error: %s does not support upgrade\n", mgr.Name())
+			return ExitErr
+		}
+		cmd := upgrader.UpgradeCmd(name)
+		if cmd == nil {
+			fmt.Fprintf(stderr, "error: %s returned no upgrade command for %q\n", mgr.Name(), name)
+			return ExitErr
+		}
+		cmdStr := strings.Join(stripSudoStdinFlag(cmd).Args, " ")
+		plans = append(plans, plan{pkg: pkg, mgr: mgr, upgrader: upgrader, cmd: cmd, cmdStr: cmdStr})
+	}
+
+	fmt.Fprintln(stdout, "The following commands will run:")
+	for _, p := range plans {
+		fmt.Fprintf(stdout, "  %s  →  %s\n", p.mgr.Name(), p.cmdStr)
+	}
+
+	if *dryRunFlag {
+		fmt.Fprintln(stdout, "(dry-run; nothing executed)")
+		return ExitOK
+	}
+
+	if !*yesFlag {
+		if !confirmAction("Proceed? [y/N] ", stdin, stdout) {
+			fmt.Fprintln(stderr, "cancelled")
+			return ExitOK
+		}
+	}
+
+	for _, p := range plans {
+		if !*quietFlag {
+			fmt.Fprintf(stderr, "upgrading %s via %s...\n", p.pkg.Name, p.mgr.Name())
+		}
+		cmd := p.upgrader.UpgradeCmd(p.pkg.Name)
+		if err := headlessExec(cmd); err != nil {
+			fmt.Fprintf(stderr, "error: upgrade %s failed: %v\n", p.pkg.Name, err)
+			return ExitErr
+		}
+		invalidateAfterWrite(p.mgr, []model.Package{p.pkg})
+	}
+	return ExitOK
+}

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -25,6 +25,7 @@ func runUpgrade(args []string, mgrs []manager.Manager, version string, stdout, s
 		yesFlag    = fs.Bool("yes", false, "skip the y/N confirmation prompt")
 		dryRunFlag = fs.Bool("dry-run", false, "print the command(s) without executing")
 		quietFlag  = fs.Bool("quiet", false, "suppress progress on stderr")
+		noCacheFlag = fs.Bool("no-cache", false, "bypass the scan cache; do a fresh live scan")
 	)
 	fs.BoolVar(yesFlag, "y", false, "alias for --yes")
 	fs.BoolVar(quietFlag, "q", false, "alias for --quiet")
@@ -48,7 +49,7 @@ func runUpgrade(args []string, mgrs []manager.Manager, version string, stdout, s
 		return ExitErr
 	}
 
-	pkgs, err := collectPackages(filtered, false, true, stderr, false)
+	pkgs, err := collectPackages(filtered, *noCacheFlag, true, stderr, false)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: scan failed: %v\n", err)
 		return ExitErr

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -94,7 +94,15 @@ func runUpgrade(args []string, mgrs []manager.Manager, version string, stdout, s
 			fmt.Fprintf(stderr, "error: %s does not support upgrade\n", mgr.Name())
 			return ExitErr
 		}
-		cmd := upgrader.UpgradeCmd(name)
+		var cmd *exec.Cmd
+		if *yesFlag {
+			if ni, ok := mgr.(manager.NonInteractiveUpgrader); ok {
+				cmd = ni.UpgradeCmdYes(name)
+			}
+		}
+		if cmd == nil {
+			cmd = upgrader.UpgradeCmd(name)
+		}
 		if cmd == nil {
 			fmt.Fprintf(stderr, "error: %s returned no upgrade command for %q\n", mgr.Name(), name)
 			return ExitErr
@@ -124,7 +132,15 @@ func runUpgrade(args []string, mgrs []manager.Manager, version string, stdout, s
 		if !*quietFlag {
 			fmt.Fprintf(stderr, "upgrading %s via %s...\n", p.pkg.Name, p.mgr.Name())
 		}
-		cmd := p.upgrader.UpgradeCmd(p.pkg.Name)
+		var cmd *exec.Cmd
+		if *yesFlag {
+			if ni, ok := p.mgr.(manager.NonInteractiveUpgrader); ok {
+				cmd = ni.UpgradeCmdYes(p.pkg.Name)
+			}
+		}
+		if cmd == nil {
+			cmd = p.upgrader.UpgradeCmd(p.pkg.Name)
+		}
 		if err := headlessExec(cmd); err != nil {
 			fmt.Fprintf(stderr, "error: upgrade %s failed: %v\n", p.pkg.Name, err)
 			return ExitErr

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+func upgradeFakeMgrs() []manager.Manager {
+	return []manager.Manager{
+		&fakeManager{
+			name: model.SourcePacman, available: true,
+			scanFn: func() ([]model.Package, error) {
+				return []model.Package{
+					fakePackage("git", "2.43", model.SourcePacman),
+					fakePackage("vim", "9.0", model.SourcePacman),
+				}, nil
+			},
+			upgradeCmdFn: func(name string) *exec.Cmd {
+				return exec.Command("/bin/true", "upgrade", name)
+			},
+		},
+		&fakeManager{
+			name: model.SourceBrew, available: true,
+			scanFn: func() ([]model.Package, error) {
+				return []model.Package{fakePackage("git", "2.43", model.SourceBrew)}, nil
+			},
+			upgradeCmdFn: func(name string) *exec.Cmd {
+				return exec.Command("/bin/true", "upgrade", name)
+			},
+		},
+	}
+}
+
+func TestUpgradeNoArgs(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"upgrade"}, upgradeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d", code, ExitErr)
+	}
+}
+
+func TestUpgradeNotInstalled(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"upgrade", "nonexistent", "--yes", "--quiet"}, upgradeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitNegative {
+		t.Errorf("exit %d, want %d", code, ExitNegative)
+	}
+}
+
+func TestUpgradeAmbiguous(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// git is installed in both pacman and brew.
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"upgrade", "git", "--yes", "--quiet"}, upgradeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitAmbiguous {
+		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitAmbiguous, errOut.String())
+	}
+}
+
+func TestUpgradeExplicitManagerYes(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"upgrade", "git", "--manager", "brew", "--yes", "--quiet"}, upgradeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Fatalf("exit %d, stderr=%q", code, errOut.String())
+	}
+}
+
+func TestUpgradeDryRun(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"upgrade", "vim", "--dry-run"}, upgradeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Fatalf("exit %d", code)
+	}
+	if !strings.Contains(out.String(), "dry-run") {
+		t.Errorf("dry-run notice missing: %q", out.String())
+	}
+}
+
+func TestUpgradePromptNo(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	stdin := strings.NewReader("n\n")
+	code := Dispatch([]string{"upgrade", "vim"}, upgradeFakeMgrs(), "test", &out, &errOut, stdin)
+	if code != ExitOK {
+		t.Fatalf("cancellation exit %d", code)
+	}
+	if !strings.Contains(errOut.String(), "cancelled") {
+		t.Errorf("expected 'cancelled': %q", errOut.String())
+	}
+}
+
+func TestUpgradePromptYesExecutes(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	stdin := strings.NewReader("y\n")
+	code := Dispatch([]string{"upgrade", "vim", "--quiet"}, upgradeFakeMgrs(), "test", &out, &errOut, stdin)
+	if code != ExitOK {
+		t.Fatalf("exit %d, stderr=%q", code, errOut.String())
+	}
+}
+
+func TestUpgradeUnsupportedManager(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// Manager with scanFn returning a package but no upgradeCmdFn → not an Upgrader.
+	noUpgrade := &fakeManager{
+		name: model.SourcePacman, available: true,
+		scanFn: func() ([]model.Package, error) {
+			return []model.Package{fakePackage("hello", "1.0", model.SourcePacman)}, nil
+		},
+		// no upgradeCmdFn
+	}
+	// fakeManager implements UpgradeCmd via nil-guard returning nil — caught by
+	// the "returned no upgrade command" check.
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"upgrade", "hello", "--yes", "--quiet"}, []manager.Manager{noUpgrade}, "test", &out, &errOut, nil)
+	if code != ExitErr {
+		t.Errorf("exit %d, want %d (stderr=%q)", code, ExitErr, errOut.String())
+	}
+}
+
+func TestUpgradeHelpExitsZero(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"upgrade", "--help"}, upgradeFakeMgrs(), "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Errorf("exit %d, want %d", code, ExitOK)
+	}
+}

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -135,3 +135,34 @@ func TestUpgradeHelpExitsZero(t *testing.T) {
 		t.Errorf("exit %d, want %d", code, ExitOK)
 	}
 }
+
+func TestUpgradeYesUsesNonInteractive(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var capturedNI string
+	var capturedInteractive string
+	pacman := &fakeManager{
+		name: model.SourcePacman, available: true,
+		scanFn: func() ([]model.Package, error) {
+			return []model.Package{fakePackage("vim", "9.0", model.SourcePacman)}, nil
+		},
+		upgradeCmdFn: func(name string) *exec.Cmd {
+			capturedInteractive = name
+			return exec.Command("/bin/true", "interactive", name)
+		},
+		upgradeCmdYesFn: func(name string) *exec.Cmd {
+			capturedNI = name
+			return exec.Command("/bin/true", "noninteractive", name)
+		},
+	}
+	var out, errOut bytes.Buffer
+	code := Dispatch([]string{"upgrade", "vim", "--yes", "--quiet"}, []manager.Manager{pacman}, "test", &out, &errOut, nil)
+	if code != ExitOK {
+		t.Fatalf("exit %d, stderr=%q", code, errOut.String())
+	}
+	if capturedNI != "vim" {
+		t.Errorf("expected non-interactive variant to be called with vim, got %q", capturedNI)
+	}
+	if capturedInteractive != "" {
+		t.Errorf("expected interactive variant NOT to be called, but got %q", capturedInteractive)
+	}
+}

--- a/internal/manager/apt.go
+++ b/internal/manager/apt.go
@@ -202,3 +202,19 @@ func (a *Apt) Search(query string) ([]model.Package, error) {
 func (a *Apt) InstallCmd(name string) *exec.Cmd {
 	return privilegedCmd("apt-get", "install", "-y", name)
 }
+
+func (a *Apt) InstallCmdYes(name string) *exec.Cmd {
+	return privilegedCmd("apt-get", "install", "-y", name)
+}
+
+func (a *Apt) UpgradeCmdYes(name string) *exec.Cmd {
+	return privilegedCmd("apt-get", "install", "--only-upgrade", "-y", name)
+}
+
+func (a *Apt) RemoveCmdYes(name string) *exec.Cmd {
+	return privilegedCmd("apt-get", "remove", "-y", name)
+}
+
+func (a *Apt) RemoveCmdWithDepsYes(name string) *exec.Cmd {
+	return privilegedCmd("apt-get", "autoremove", "-y", name)
+}

--- a/internal/manager/aur.go
+++ b/internal/manager/aur.go
@@ -161,3 +161,21 @@ func (a *AUR) InstallCmd(name string) *exec.Cmd {
 	}
 	return exec.Command("pacman", "-S", name)
 }
+
+func (a *AUR) InstallCmdYes(name string) *exec.Cmd {
+	if h := aurHelper(); h != "" {
+		return exec.Command(h, "-S", "--noconfirm", name)
+	}
+	return exec.Command("pacman", "-S", "--noconfirm", name)
+}
+
+func (a *AUR) UpgradeCmdYes(name string) *exec.Cmd {
+	if h := aurHelper(); h != "" {
+		return exec.Command(h, "-S", "--noconfirm", name)
+	}
+	return exec.Command("pacman", "-S", "--noconfirm", name)
+}
+
+func (a *AUR) RemoveCmdYes(name string) *exec.Cmd {
+	return exec.Command("pacman", "-R", "--noconfirm", name)
+}

--- a/internal/manager/aur.go
+++ b/internal/manager/aur.go
@@ -166,14 +166,14 @@ func (a *AUR) InstallCmdYes(name string) *exec.Cmd {
 	if h := aurHelper(); h != "" {
 		return exec.Command(h, "-S", "--noconfirm", name)
 	}
-	return exec.Command("pacman", "-S", "--noconfirm", name)
+	return privilegedCmd("pacman", "-S", "--noconfirm", name)
 }
 
 func (a *AUR) UpgradeCmdYes(name string) *exec.Cmd {
 	if h := aurHelper(); h != "" {
 		return exec.Command(h, "-S", "--noconfirm", name)
 	}
-	return exec.Command("pacman", "-S", "--noconfirm", name)
+	return privilegedCmd("pacman", "-S", "--noconfirm", name)
 }
 
 func (a *AUR) RemoveCmdYes(name string) *exec.Cmd {

--- a/internal/manager/aur.go
+++ b/internal/manager/aur.go
@@ -177,5 +177,5 @@ func (a *AUR) UpgradeCmdYes(name string) *exec.Cmd {
 }
 
 func (a *AUR) RemoveCmdYes(name string) *exec.Cmd {
-	return exec.Command("pacman", "-R", "--noconfirm", name)
+	return privilegedCmd("pacman", "-R", "--noconfirm", name)
 }

--- a/internal/manager/chocolatey.go
+++ b/internal/manager/chocolatey.go
@@ -202,3 +202,15 @@ func (c *Chocolatey) Describe(pkgs []model.Package) map[string]string {
 func (c *Chocolatey) InstallCmd(name string) *exec.Cmd {
 	return exec.Command("choco", "install", name, "--yes")
 }
+
+func (c *Chocolatey) InstallCmdYes(name string) *exec.Cmd {
+	return exec.Command("choco", "install", name, "--yes")
+}
+
+func (c *Chocolatey) UpgradeCmdYes(name string) *exec.Cmd {
+	return exec.Command("choco", "upgrade", name, "--yes")
+}
+
+func (c *Chocolatey) RemoveCmdYes(name string) *exec.Cmd {
+	return exec.Command("choco", "uninstall", name, "--yes")
+}

--- a/internal/manager/dnf.go
+++ b/internal/manager/dnf.go
@@ -186,3 +186,19 @@ func (d *Dnf) Search(query string) ([]model.Package, error) {
 func (d *Dnf) InstallCmd(name string) *exec.Cmd {
 	return privilegedCmd("dnf", "install", "-y", name)
 }
+
+func (d *Dnf) InstallCmdYes(name string) *exec.Cmd {
+	return privilegedCmd("dnf", "install", "-y", name)
+}
+
+func (d *Dnf) UpgradeCmdYes(name string) *exec.Cmd {
+	return privilegedCmd("dnf", "upgrade", "-y", name)
+}
+
+func (d *Dnf) RemoveCmdYes(name string) *exec.Cmd {
+	return privilegedCmd("dnf", "remove", "-y", name)
+}
+
+func (d *Dnf) RemoveCmdWithDepsYes(name string) *exec.Cmd {
+	return privilegedCmd("dnf", "autoremove", "-y", name)
+}

--- a/internal/manager/noninteractive.go
+++ b/internal/manager/noninteractive.go
@@ -1,0 +1,27 @@
+package manager
+
+import "os/exec"
+
+// NonInteractiveInstaller is implemented by managers that have a way to
+// suppress their interactive y/N prompt during install (e.g., pacman's
+// --noconfirm, apt's -y). When the gpk caller passes --yes, gpk uses this
+// variant if available; otherwise it falls back to InstallCmd and the user
+// must answer the manager's own prompt.
+type NonInteractiveInstaller interface {
+	InstallCmdYes(name string) *exec.Cmd
+}
+
+// NonInteractiveUpgrader: same as NonInteractiveInstaller but for upgrade.
+type NonInteractiveUpgrader interface {
+	UpgradeCmdYes(name string) *exec.Cmd
+}
+
+// NonInteractiveRemover: same shape, for remove.
+type NonInteractiveRemover interface {
+	RemoveCmdYes(name string) *exec.Cmd
+}
+
+// NonInteractiveDeepRemover: same shape, for remove --with-deps.
+type NonInteractiveDeepRemover interface {
+	RemoveCmdWithDepsYes(name string) *exec.Cmd
+}

--- a/internal/manager/pacman.go
+++ b/internal/manager/pacman.go
@@ -205,6 +205,22 @@ func (p *Pacman) InstallCmd(name string) *exec.Cmd {
 	return privilegedCmd("pacman", "-S", name)
 }
 
+func (p *Pacman) InstallCmdYes(name string) *exec.Cmd {
+	return privilegedCmd("pacman", "-S", "--noconfirm", name)
+}
+
+func (p *Pacman) UpgradeCmdYes(name string) *exec.Cmd {
+	return privilegedCmd("pacman", "-S", "--noconfirm", name)
+}
+
+func (p *Pacman) RemoveCmdYes(name string) *exec.Cmd {
+	return privilegedCmd("pacman", "-R", "--noconfirm", name)
+}
+
+func (p *Pacman) RemoveCmdWithDepsYes(name string) *exec.Cmd {
+	return privilegedCmd("pacman", "-Rns", "--noconfirm", name)
+}
+
 func parseField(line string) (key, val string, ok bool) {
 	idx := strings.Index(line, ":")
 	if idx < 0 {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -583,7 +583,7 @@ func (m *Model) upgradeDetailPackage() tea.Cmd {
 		return nil
 	}
 
-	cmd := upgrader.UpgradeCmd(pkg.Name)
+	cmd := upgradeCmdFor(mgr, upgrader, pkg.Name)
 	cmdStr := strings.Join(cmd.Args, " ")
 	needsSudo := len(cmd.Args) > 0 && cmd.Args[0] == "sudo"
 	req := &upgradeRequest{
@@ -1739,6 +1739,51 @@ func upgradeConfirmBody(m *Model) string {
 	return b.String()
 }
 
+// upgradeCmdFor returns the non-interactive upgrade command when the manager
+// supports it (pacman, aur, apt, dnf, chocolatey), falling back to the
+// interactive command. The TUI's modal already serves as user confirmation,
+// so a second pacman/yay prompt is both redundant and broken — once the
+// upgrade subprocess opens, the TUI is no longer connected to a tty that can
+// answer y/N.
+func upgradeCmdFor(mgr manager.Manager, up manager.Upgrader, name string) *exec.Cmd {
+	if ni, ok := mgr.(manager.NonInteractiveUpgrader); ok {
+		if cmd := ni.UpgradeCmdYes(name); cmd != nil {
+			return cmd
+		}
+	}
+	return up.UpgradeCmd(name)
+}
+
+// removeCmdFor mirrors upgradeCmdFor for the interactive remove path.
+func removeCmdFor(mgr manager.Manager, rm manager.Remover, name string) *exec.Cmd {
+	if ni, ok := mgr.(manager.NonInteractiveRemover); ok {
+		if cmd := ni.RemoveCmdYes(name); cmd != nil {
+			return cmd
+		}
+	}
+	return rm.RemoveCmd(name)
+}
+
+// deepRemoveCmdFor mirrors the helpers for the "remove + orphan deps" path.
+func deepRemoveCmdFor(mgr manager.Manager, dr manager.DeepRemover, name string) *exec.Cmd {
+	if ni, ok := mgr.(manager.NonInteractiveDeepRemover); ok {
+		if cmd := ni.RemoveCmdWithDepsYes(name); cmd != nil {
+			return cmd
+		}
+	}
+	return dr.RemoveCmdWithDeps(name)
+}
+
+// installCmdFor mirrors the helpers for install (used by the search-install flow).
+func installCmdFor(mgr manager.Manager, inst manager.Installer, name string) *exec.Cmd {
+	if ni, ok := mgr.(manager.NonInteractiveInstaller); ok {
+		if cmd := ni.InstallCmdYes(name); cmd != nil {
+			return cmd
+		}
+	}
+	return inst.InstallCmd(name)
+}
+
 func isPrivilegedSource(source model.Source) bool {
 	switch source {
 	case model.SourceApt, model.SourceDnf, model.SourcePacman, model.SourceSnap,
@@ -1775,7 +1820,7 @@ func (m *Model) removeDetailPackage() tea.Cmd {
 		return nil
 	}
 
-	cmd := remover.RemoveCmd(pkg.Name)
+	cmd := removeCmdFor(mgr, remover, pkg.Name)
 	req := &removeRequest{
 		pkg:        pkg,
 		cmd:        cmd,
@@ -1784,7 +1829,7 @@ func (m *Model) removeDetailPackage() tea.Cmd {
 	}
 
 	if deep, ok := mgr.(manager.DeepRemover); ok {
-		deepCmd := deep.RemoveCmdWithDeps(pkg.Name)
+		deepCmd := deepRemoveCmdFor(mgr, deep, pkg.Name)
 		req.deepCmd = deepCmd
 		req.deepCmdStr = strings.Join(deepCmd.Args, " ")
 	}

--- a/internal/ui/install_search.go
+++ b/internal/ui/install_search.go
@@ -255,6 +255,10 @@ func (m *Model) installFromSearch() tea.Cmd {
 	}
 
 	cmd := installCmdFor(mgr, installer, pkg.Name)
+	if cmd == nil {
+		m.statusMsg = fmt.Sprintf("%s returned no install command for %q", mgr.Name(), pkg.Name)
+		return nil
+	}
 	cmdStr := strings.Join(cmd.Args, " ")
 	needsSudo := len(cmd.Args) > 0 && cmd.Args[0] == "sudo"
 

--- a/internal/ui/install_search.go
+++ b/internal/ui/install_search.go
@@ -254,7 +254,7 @@ func (m *Model) installFromSearch() tea.Cmd {
 		return nil
 	}
 
-	cmd := installer.InstallCmd(pkg.Name)
+	cmd := installCmdFor(mgr, installer, pkg.Name)
 	cmdStr := strings.Join(cmd.Args, " ")
 	needsSudo := len(cmd.Args) > 0 && cmd.Args[0] == "sudo"
 

--- a/internal/ui/multiselect.go
+++ b/internal/ui/multiselect.go
@@ -96,7 +96,7 @@ func (m *Model) batchUpgradeSelected() tea.Cmd {
 			skipped = append(skipped, pkg.Name)
 			continue
 		}
-		cmd := upgrader.UpgradeCmd(pkg.Name)
+		cmd := upgradeCmdFor(mgr, upgrader, pkg.Name)
 		ops = append(ops, batchOp{
 			pkg:        pkg,
 			cmd:        cmd,
@@ -136,7 +136,7 @@ func (m *Model) batchRemoveSelected() tea.Cmd {
 			skipped = append(skipped, pkg.Name)
 			continue
 		}
-		cmd := remover.RemoveCmd(pkg.Name)
+		cmd := removeCmdFor(mgr, remover, pkg.Name)
 		ops = append(ops, batchOp{
 			pkg:        pkg,
 			cmd:        cmd,

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -18,7 +18,7 @@ func TestCLI_ListJSON(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := cli.Dispatch(
 		[]string{"list", "--json", "--no-cache", "--quiet"},
-		manager.All(), "integration-test", &out, &errOut,
+		manager.All(), "integration-test", &out, &errOut, nil,
 	)
 	if code != 0 {
 		t.Fatalf("exit %d, stderr=%q", code, errOut.String())
@@ -42,7 +42,7 @@ func TestCLI_InstalledMissing(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := cli.Dispatch(
 		[]string{"installed", "definitely-not-a-real-package-xyz-zzz", "--no-cache", "--quiet"},
-		manager.All(), "integration-test", &out, &errOut,
+		manager.All(), "integration-test", &out, &errOut, nil,
 	)
 	if code != 2 {
 		t.Fatalf("exit %d, want 2 (stderr=%q)", code, errOut.String())
@@ -55,7 +55,7 @@ func TestCLI_OutdatedCountFormat(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := cli.Dispatch(
 		[]string{"outdated", "--count", "--quiet"},
-		manager.All(), "integration-test", &out, &errOut,
+		manager.All(), "integration-test", &out, &errOut, nil,
 	)
 	if code != 0 {
 		t.Fatalf("exit %d, stderr=%q", code, errOut.String())
@@ -71,7 +71,7 @@ func TestCLI_SourceOfMissing(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := cli.Dispatch(
 		[]string{"source-of", "--no-cache", "definitely-not-a-real-package-xyz-zzz"},
-		manager.All(), "integration-test", &out, &errOut,
+		manager.All(), "integration-test", &out, &errOut, nil,
 	)
 	if code != 2 {
 		t.Fatalf("exit %d, want 2", code)
@@ -87,7 +87,7 @@ func TestCLI_UnknownSubcommand(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := cli.Dispatch(
 		[]string{"definitely-not-a-real-subcommand"},
-		manager.All(), "integration-test", &out, &errOut,
+		manager.All(), "integration-test", &out, &errOut, nil,
 	)
 	if code != 1 {
 		t.Fatalf("exit %d, want 1", code)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/neur0map/glazepkg/internal/cli"
@@ -91,5 +92,50 @@ func TestCLI_UnknownSubcommand(t *testing.T) {
 	)
 	if code != 1 {
 		t.Fatalf("exit %d, want 1", code)
+	}
+}
+
+// TestCLI_UpgradeDryRun verifies the upgrade command can resolve and build
+// a command against real installed packages without actually executing.
+// Skips if no packages have updates (nothing to upgrade).
+func TestCLI_UpgradeDryRun(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// First find an outdated package on this system.
+	var outBuf, errBuf bytes.Buffer
+	code := cli.Dispatch(
+		[]string{"outdated", "--json", "--no-cache", "--quiet"},
+		manager.All(), "integration-test", &outBuf, &errBuf, nil,
+	)
+	if code != 0 {
+		t.Skipf("outdated failed (exit %d), skipping: %s", code, errBuf.String())
+	}
+	var env struct {
+		Data []struct {
+			Name   string `json:"name"`
+			Source string `json:"source"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(outBuf.Bytes(), &env); err != nil {
+		t.Skipf("invalid outdated JSON: %v", err)
+	}
+	if len(env.Data) == 0 {
+		t.Skip("no outdated packages on this system; nothing to dry-run upgrade")
+	}
+	target := env.Data[0]
+
+	// Now dry-run upgrade against the first outdated package.
+	var out, errOut bytes.Buffer
+	code = cli.Dispatch(
+		[]string{"upgrade", target.Name, "--dry-run", "--quiet", "--manager", target.Source},
+		manager.All(), "integration-test", &out, &errOut, nil,
+	)
+	if code != 0 {
+		t.Fatalf("upgrade dry-run exit %d, stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), target.Name) {
+		t.Errorf("dry-run output should mention %q: %q", target.Name, out.String())
+	}
+	if !strings.Contains(out.String(), "dry-run") {
+		t.Errorf("expected dry-run notice in stdout: %q", out.String())
 	}
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1,0 +1,95 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/neur0map/glazepkg/internal/cli"
+	"github.com/neur0map/glazepkg/internal/manager"
+)
+
+// TestCLI_ListJSON runs `gpk list --json` against real managers and verifies
+// the envelope shape. Doesn't care how many packages are present — runners
+// may have zero managers and zero packages; data being an array is enough.
+func TestCLI_ListJSON(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := cli.Dispatch(
+		[]string{"list", "--json", "--no-cache", "--quiet"},
+		manager.All(), "integration-test", &out, &errOut,
+	)
+	if code != 0 {
+		t.Fatalf("exit %d, stderr=%q", code, errOut.String())
+	}
+	var env struct {
+		Schema int               `json:"schema"`
+		Data   []json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody=%s", err, out.String())
+	}
+	if env.Schema != 1 {
+		t.Errorf("schema = %d, want 1", env.Schema)
+	}
+	// env.Data may be nil if no managers and no packages; that's OK.
+}
+
+// TestCLI_InstalledMissing verifies the exit-2 contract for absent packages.
+func TestCLI_InstalledMissing(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := cli.Dispatch(
+		[]string{"installed", "definitely-not-a-real-package-xyz-zzz", "--no-cache", "--quiet"},
+		manager.All(), "integration-test", &out, &errOut,
+	)
+	if code != 2 {
+		t.Fatalf("exit %d, want 2 (stderr=%q)", code, errOut.String())
+	}
+}
+
+// TestCLI_OutdatedCountFormat verifies `--count` output is exactly a number.
+func TestCLI_OutdatedCountFormat(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := cli.Dispatch(
+		[]string{"outdated", "--count", "--quiet"},
+		manager.All(), "integration-test", &out, &errOut,
+	)
+	if code != 0 {
+		t.Fatalf("exit %d, stderr=%q", code, errOut.String())
+	}
+	if !regexp.MustCompile(`^[0-9]+\n$`).Match(out.Bytes()) {
+		t.Errorf("--count output = %q, want /^[0-9]+\\n$/", out.String())
+	}
+}
+
+// TestCLI_SourceOfMissing verifies the exit-2 + empty-stdout contract.
+func TestCLI_SourceOfMissing(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := cli.Dispatch(
+		[]string{"source-of", "--no-cache", "definitely-not-a-real-package-xyz-zzz"},
+		manager.All(), "integration-test", &out, &errOut,
+	)
+	if code != 2 {
+		t.Fatalf("exit %d, want 2", code)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout = %q, want empty on exit 2", out.String())
+	}
+}
+
+// TestCLI_UnknownSubcommand verifies the dispatcher rejects unknown names.
+func TestCLI_UnknownSubcommand(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	var out, errOut bytes.Buffer
+	code := cli.Dispatch(
+		[]string{"definitely-not-a-real-subcommand"},
+		manager.All(), "integration-test", &out, &errOut,
+	)
+	if code != 1 {
+		t.Fatalf("exit %d, want 1", code)
+	}
+}

--- a/tests/integration/manager_audit_test.go
+++ b/tests/integration/manager_audit_test.go
@@ -1,0 +1,159 @@
+package integration
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/neur0map/glazepkg/internal/manager"
+)
+
+// TestManagerCapabilityMatrix prints a matrix of which managers implement
+// which write-capability interfaces. Doesn't fail the test on missing caps —
+// the output IS the assertion artifact.
+//
+// Run with: go test ./tests/integration/... -run TestManagerCapabilityMatrix -v
+func TestManagerCapabilityMatrix(t *testing.T) {
+	headers := []string{"manager", "avail", "Inst", "Inst+y", "Up", "Up+y", "Rm", "Rm+y", "Deep", "Deep+y"}
+	t.Log(formatRow(headers, headerWidths))
+	t.Log(formatRow([]string{strings.Repeat("-", 18), "-----", "----", "------", "--", "----", "--", "----", "----", "------"}, headerWidths))
+	for _, m := range manager.All() {
+		name := string(m.Name())
+		avail := "no"
+		if m.Available() {
+			avail = "YES"
+		}
+		row := []string{
+			name,
+			avail,
+			hasIface(m, "Installer"),
+			hasIface(m, "NonInteractiveInstaller"),
+			hasIface(m, "Upgrader"),
+			hasIface(m, "NonInteractiveUpgrader"),
+			hasIface(m, "Remover"),
+			hasIface(m, "NonInteractiveRemover"),
+			hasIface(m, "DeepRemover"),
+			hasIface(m, "NonInteractiveDeepRemover"),
+		}
+		t.Log(formatRow(row, headerWidths))
+	}
+}
+
+var headerWidths = []int{18, 5, 4, 6, 2, 4, 2, 4, 4, 6}
+
+func formatRow(cells []string, widths []int) string {
+	var b strings.Builder
+	for i, c := range cells {
+		if i > 0 {
+			b.WriteString("  ")
+		}
+		b.WriteString(fmt.Sprintf("%-*s", widths[i], c))
+	}
+	return b.String()
+}
+
+// hasIface returns "✓" if m implements the named interface, "-" if not.
+// Implemented as a switch on string name because Go doesn't have reflective
+// "does this implement interface named X" without explicit type assertions.
+func hasIface(m manager.Manager, name string) string {
+	yes, no := "✓", "-"
+	switch name {
+	case "Installer":
+		if _, ok := m.(manager.Installer); ok {
+			return yes
+		}
+	case "NonInteractiveInstaller":
+		if _, ok := m.(manager.NonInteractiveInstaller); ok {
+			return yes
+		}
+	case "Upgrader":
+		if _, ok := m.(manager.Upgrader); ok {
+			return yes
+		}
+	case "NonInteractiveUpgrader":
+		if _, ok := m.(manager.NonInteractiveUpgrader); ok {
+			return yes
+		}
+	case "Remover":
+		if _, ok := m.(manager.Remover); ok {
+			return yes
+		}
+	case "NonInteractiveRemover":
+		if _, ok := m.(manager.NonInteractiveRemover); ok {
+			return yes
+		}
+	case "DeepRemover":
+		if _, ok := m.(manager.DeepRemover); ok {
+			return yes
+		}
+	case "NonInteractiveDeepRemover":
+		if _, ok := m.(manager.NonInteractiveDeepRemover); ok {
+			return yes
+		}
+	}
+	return no
+}
+
+// TestManagerCommandSamples prints the actual *exec.Cmd args that each
+// manager would produce for a dummy package called "DUMMY" — both
+// interactive and non-interactive variants. Lets the user audit that the
+// commands are sensible without running them.
+func TestManagerCommandSamples(t *testing.T) {
+	const pkg = "DUMMY"
+	for _, m := range manager.All() {
+		t.Run(string(m.Name()), func(t *testing.T) {
+			lines := []string{fmt.Sprintf("=== %s ===", m.Name())}
+			lines = append(lines, fmt.Sprintf("  available: %v", m.Available()))
+
+			if inst, ok := m.(manager.Installer); ok {
+				lines = append(lines, fmt.Sprintf("  install:        %s", joinArgs(inst.InstallCmd(pkg))))
+			} else {
+				lines = append(lines, "  install:        (not supported)")
+			}
+			if ni, ok := m.(manager.NonInteractiveInstaller); ok {
+				lines = append(lines, fmt.Sprintf("  install --yes:  %s", joinArgs(ni.InstallCmdYes(pkg))))
+			} else {
+				lines = append(lines, "  install --yes:  (falls back to interactive)")
+			}
+
+			if up, ok := m.(manager.Upgrader); ok {
+				lines = append(lines, fmt.Sprintf("  upgrade:        %s", joinArgs(up.UpgradeCmd(pkg))))
+			} else {
+				lines = append(lines, "  upgrade:        (not supported)")
+			}
+			if ni, ok := m.(manager.NonInteractiveUpgrader); ok {
+				lines = append(lines, fmt.Sprintf("  upgrade --yes:  %s", joinArgs(ni.UpgradeCmdYes(pkg))))
+			} else {
+				lines = append(lines, "  upgrade --yes:  (falls back to interactive)")
+			}
+
+			if rm, ok := m.(manager.Remover); ok {
+				lines = append(lines, fmt.Sprintf("  remove:         %s", joinArgs(rm.RemoveCmd(pkg))))
+			} else {
+				lines = append(lines, "  remove:         (not supported)")
+			}
+			if ni, ok := m.(manager.NonInteractiveRemover); ok {
+				lines = append(lines, fmt.Sprintf("  remove --yes:   %s", joinArgs(ni.RemoveCmdYes(pkg))))
+			} else {
+				lines = append(lines, "  remove --yes:   (falls back to interactive)")
+			}
+
+			if dr, ok := m.(manager.DeepRemover); ok {
+				lines = append(lines, fmt.Sprintf("  remove deps:    %s", joinArgs(dr.RemoveCmdWithDeps(pkg))))
+			}
+			if ni, ok := m.(manager.NonInteractiveDeepRemover); ok {
+				lines = append(lines, fmt.Sprintf("  remove deps -y: %s", joinArgs(ni.RemoveCmdWithDepsYes(pkg))))
+			}
+
+			t.Log(strings.Join(lines, "\n"))
+		})
+	}
+}
+
+func joinArgs(cmd *exec.Cmd) string {
+	if cmd == nil {
+		return "(nil)"
+	}
+	return cmd.String()
+}

--- a/tests/integration/manager_audit_test.go
+++ b/tests/integration/manager_audit_test.go
@@ -10,14 +10,21 @@ import (
 )
 
 // TestManagerCapabilityMatrix prints a matrix of which managers implement
-// which write-capability interfaces. Doesn't fail the test on missing caps —
+// which read and write interfaces. Doesn't fail the test on missing caps —
 // the output IS the assertion artifact.
 //
 // Run with: go test ./tests/integration/... -run TestManagerCapabilityMatrix -v
 func TestManagerCapabilityMatrix(t *testing.T) {
-	headers := []string{"manager", "avail", "Inst", "Inst+y", "Up", "Up+y", "Rm", "Rm+y", "Deep", "Deep+y"}
+	headers := []string{"manager", "avail", "Scan", "Desc", "Deps", "Updates", "Search", "Inst", "Inst+y", "Up", "Up+y", "Rm", "Rm+y", "Deep", "Deep+y"}
 	t.Log(formatRow(headers, headerWidths))
-	t.Log(formatRow([]string{strings.Repeat("-", 18), "-----", "----", "------", "--", "----", "--", "----", "----", "------"}, headerWidths))
+	t.Log(formatRow([]string{
+		strings.Repeat("-", 18), strings.Repeat("-", 5),
+		strings.Repeat("-", 4), strings.Repeat("-", 4), strings.Repeat("-", 5),
+		strings.Repeat("-", 7), strings.Repeat("-", 6),
+		strings.Repeat("-", 4), strings.Repeat("-", 6), strings.Repeat("-", 2),
+		strings.Repeat("-", 4), strings.Repeat("-", 2), strings.Repeat("-", 4),
+		strings.Repeat("-", 4), strings.Repeat("-", 6),
+	}, headerWidths))
 	for _, m := range manager.All() {
 		name := string(m.Name())
 		avail := "no"
@@ -27,6 +34,11 @@ func TestManagerCapabilityMatrix(t *testing.T) {
 		row := []string{
 			name,
 			avail,
+			"✓", // Scan: every Manager has it
+			hasIface(m, "Describer"),
+			hasIface(m, "DependencyLister"),
+			hasIface(m, "UpdateChecker"),
+			hasIface(m, "Searcher"),
 			hasIface(m, "Installer"),
 			hasIface(m, "NonInteractiveInstaller"),
 			hasIface(m, "Upgrader"),
@@ -40,7 +52,7 @@ func TestManagerCapabilityMatrix(t *testing.T) {
 	}
 }
 
-var headerWidths = []int{18, 5, 4, 6, 2, 4, 2, 4, 4, 6}
+var headerWidths = []int{18, 5, 4, 4, 5, 7, 6, 4, 6, 2, 4, 2, 4, 4, 6}
 
 func formatRow(cells []string, widths []int) string {
 	var b strings.Builder
@@ -59,6 +71,22 @@ func formatRow(cells []string, widths []int) string {
 func hasIface(m manager.Manager, name string) string {
 	yes, no := "✓", "-"
 	switch name {
+	case "Describer":
+		if _, ok := m.(manager.Describer); ok {
+			return yes
+		}
+	case "DependencyLister":
+		if _, ok := m.(manager.DependencyLister); ok {
+			return yes
+		}
+	case "UpdateChecker":
+		if _, ok := m.(manager.UpdateChecker); ok {
+			return yes
+		}
+	case "Searcher":
+		if _, ok := m.(manager.Searcher); ok {
+			return yes
+		}
 	case "Installer":
 		if _, ok := m.(manager.Installer); ok {
 			return yes


### PR DESCRIPTION
closes #56. elkin opened that one asking for a headless mode + json output for ai-agent toolchains. i needed the same surface for ryoku-arch's update detection at the same time, so the two requirements ended up pulling the same direction and ship as one feature.

read-only first, no sudo:

- `gpk list [--manager M] [--json]` — same data as the tui's ALL tab
- `gpk installed <pkg>...` — exit 0 if every named pkg is installed, 2 if any is missing. multi-arg so `if gpk installed git jq fzf --quiet` works as one call.
- `gpk info <pkg>` — single-pkg detail, optional `--json`
- `gpk source-of <pkg>` — which manager owns the name (replaces the `pacman -Qi X` + `pacman -Qm X` two-step)
- `gpk outdated [--count] [--exit-code] [--json]` — `--count` emits a single integer (drop-in for `checkupdates | wc -l`), `--exit-code` does the apt-style "exit 2 if any updates" thing for ci gates

every read takes `--manager M` with comma list and negation (`pacman,aur`, `!brew,!cask`), respects the existing scan/update caches with `--no-cache` to bypass, and emits a stable envelope `{gpk_version, schema, data}`.

writes follow the same shape:

- `gpk install / remove / upgrade <pkg>...` with `--yes` to skip prompts, `--dry-run` to preview, `--with-deps` on remove for managers that support orphan cleanup
- ambiguity is exit 3 — `"ripgrep" available in 3 managers: pacman, brew, cargo; use --manager to pick`
- sudo goes via the controlling tty (no password modal — the tui keeps `-S` for its own flow)
- when `--yes` is set, the underlying tool's prompt is also skipped for the 5 managers that prompt by default (pacman, aur, apt, dnf, chocolatey) via new `NonInteractive*` interfaces. the other ~30 either don't prompt or already include the flag in their base command, so `--yes` is a safe no-op there.

**ryoku context:** https://github.com/neur0map/ryoku-arch has two specific call sites that immediately benefit:

- `shell/services/Updates.qml:64` polls `checkupdates | wc -l` for the bar badge. `gpk outdated --count --manager pacman,aur` picks up aur for free, could extend to `pacman,aur,brew,cargo` later for the user-space view.
- `shell/sdata/lib/doctor.sh` has ~15 `pacman -Q X &>/dev/null` calls for the conflicting-shell loop and the quickshell variant cascade (`pacman -Qi quickshell-git` then `-bin` then base, then `pacman -Qm` to discriminate aur vs repo). `gpk installed X --manager pacman,aur --quiet` + `gpk source-of X --manager pacman,aur` collapse those and stay manager-agnostic — if a conflicting shell ever ships as a flatpak the check still works.

both repos are mine but nothing in the cli surface is ryoku-specific.

stable contract for scripts / qml / ci (full reference in [COMPATIBILITY.md](COMPATIBILITY.md), one row per manager × capability):

- exit 0 — success / yes
- exit 1 — error
- exit 2 — meaningful no (not installed, not found, has updates with `--exit-code`)
- exit 3 — ambiguous write op
- json envelope `{gpk_version, schema, data}`, schema=1, additive forever or bumped on break
- stdout = answer, stderr = progress + errors, `--quiet` silences progress, ansi stripped when not a tty

not in this PR (deliberate): snapshot / diff / export from headless, `gpk upgrade --all`, `gpk edit` for user notes. those follow if the contract here holds up.

## test plan

- [x] `go test ./...` — 100+ unit tests in `internal/cli`, fake managers covering every capability interface
- [x] `tests/integration/cli_test.go` exercises `cli.Dispatch` against the real `manager.All()` — picked up by both existing macos/linux integration jobs
- [x] `tests/integration/manager_audit_test.go` walks every manager and asserts the cmd it constructs (this is COMPATIBILITY.md's source of truth, regenerable)
- [x] live smoke on arch: `gpk list / installed / info / source-of / outdated` plus `--dry-run install/remove/upgrade` across pacman, aur, npm (the three populated managers on this system)
- [x] real `gpk upgrade winetricks postgresql-libs linux-headers linux --yes` against my own system update — the actual ryoku use case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI subcommands: info, install, installed, list, outdated, remove, source-of, upgrade.
  * New flags: --manager (filter managers), --yes (non-interactive), --json, --dry-run, --quiet.
  * CLI now prefers non-interactive “yes” variants when available and shows improved terminal-aware, colorized help.

* **Documentation**
  * Added a comprehensive compatibility guide with features, capability matrix, examples, and verification steps.

* **Tests**
  * CI now runs a broader Go test suite including new CLI unit and integration tests.

* **Chores**
  * .gitignore updated to ignore .worktrees/.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neur0map/glazepkg/pull/57)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->