### PR TITLE
Fix gpk update on Linux for /usr/bin installs

### DIFF
--- a/internal/updater/replace_unix.go
+++ b/internal/updater/replace_unix.go
@@ -2,9 +2,44 @@
 
 package updater
 
-// replaceBinary overwrites dest with src. On Unix the running process keeps
-// the old inode open via its existing file descriptor, so a straight atomic
-// rename is safe even while gpk is still running.
+import "os"
+
+// renameFile is os.Rename in production; tests override it to simulate the
+// cross-filesystem failure that triggers the rename-aside path.
+var renameFile = os.Rename
+
+// replaceBinary overwrites dest with src.
+//
+// Same-filesystem fast path: a straight rename. The running gpk process
+// keeps the old inode open via its existing file descriptor, so the rename
+// is safe even while gpk is still running.
+//
+// Cross-filesystem path: when src lives on a different mount than dest
+// (typical: /tmp is tmpfs, dest is /usr/bin on disk), os.Rename returns
+// EXDEV. The fallback in moveFile then tries os.OpenFile(dest, O_TRUNC),
+// which Linux refuses with ETXTBSY ("text file busy") because dest is the
+// currently-running executable.
+//
+// To get past ETXTBSY we do the same rename-out-of-the-way dance as
+// Windows: move dest to "<dest>.old" first (which works for a running
+// binary because rename keeps the inode), then copy src into the now-vacant
+// dest path. The .old binary can be unlinked immediately afterwards on
+// Unix; the kernel preserves the inode for the running process until exit.
 func replaceBinary(src, dest string) error {
-	return moveFile(src, dest)
+	if err := renameFile(src, dest); err == nil {
+		return nil
+	}
+
+	oldPath := dest + ".old"
+	_ = os.Remove(oldPath) // best-effort cleanup of a stale .old from a prior failed update
+
+	if err := os.Rename(dest, oldPath); err != nil {
+		return err
+	}
+	if err := moveFile(src, dest); err != nil {
+		_ = os.Rename(oldPath, dest) // roll back so the user isn't left with no binary at dest
+		return err
+	}
+	_ = os.Remove(oldPath) // safe: Unix lets you unlink a running binary; the inode lives on
+	return nil
 }

--- a/internal/updater/replace_unix_test.go
+++ b/internal/updater/replace_unix_test.go
@@ -1,0 +1,112 @@
+//go:build !windows
+
+package updater
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceBinary_SameFilesystemFastPath(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dest := filepath.Join(dir, "dest")
+	if err := os.WriteFile(src, []byte("new"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+
+	if err := replaceBinary(src, dest); err != nil {
+		t.Fatalf("replaceBinary: %v", err)
+	}
+
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(body) != "new" {
+		t.Errorf("dest = %q, want %q", body, "new")
+	}
+	if _, err := os.Stat(src); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("src should be gone after rename, got err=%v", err)
+	}
+}
+
+func TestReplaceBinary_CrossFilesystemUsesRenameAside(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dest := filepath.Join(dir, "dest")
+	if err := os.WriteFile(src, []byte("new"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+
+	// Force the initial rename to fail, mimicking EXDEV when src and dest
+	// are on different filesystems. The aside path should still succeed
+	// because moveFile's internal copy creates a fresh dest after the .old
+	// rename has freed the path.
+	saved := renameFile
+	renameFile = func(s, d string) error {
+		if s == src && d == dest {
+			return errors.New("simulated cross-filesystem failure")
+		}
+		return os.Rename(s, d)
+	}
+	t.Cleanup(func() { renameFile = saved })
+
+	if err := replaceBinary(src, dest); err != nil {
+		t.Fatalf("replaceBinary: %v", err)
+	}
+
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(body) != "new" {
+		t.Errorf("dest = %q, want %q", body, "new")
+	}
+	if _, err := os.Stat(dest + ".old"); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("dest.old should be removed after success, got err=%v", err)
+	}
+}
+
+func TestReplaceBinary_CrossFilesystemRollsBackOnCopyFailure(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dest := filepath.Join(dir, "dest")
+	if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	// src deliberately does not exist; moveFile inside replaceBinary will
+	// fail trying to open it for the copy fallback, and the rollback should
+	// restore dest from the .old we renamed aside.
+
+	saved := renameFile
+	renameFile = func(s, d string) error {
+		if s == src && d == dest {
+			return errors.New("simulated cross-filesystem failure")
+		}
+		return os.Rename(s, d)
+	}
+	t.Cleanup(func() { renameFile = saved })
+
+	err := replaceBinary(src, dest)
+	if err == nil {
+		t.Fatal("expected an error when src is missing")
+	}
+
+	body, readErr := os.ReadFile(dest)
+	if readErr != nil {
+		t.Fatalf("dest should have been rolled back to its original content, but read failed: %v", readErr)
+	}
+	if string(body) != "old" {
+		t.Errorf("dest should still contain old content after rollback, got %q", body)
+	}
+}


### PR DESCRIPTION
caught this trying \`sudo gpk update\` from a v0.4.6 binary at /usr/bin/gpk: pacman put us in the spot the windows code already handled, just under a different kernel error.

flow on a stock arch box (/tmp is tmpfs, /usr is on disk):

1. \`stageDownload\` writes the new binary to /tmp/gpk-update-XXXX
2. \`replaceBinary\` (unix) just calls \`moveFile\`
3. \`os.Rename(/tmp/..., /usr/bin/gpk)\` fails with EXDEV because tmpfs and disk are different mounts
4. fallback tries \`os.OpenFile(/usr/bin/gpk, O_TRUNC)\` which the kernel refuses with ETXTBSY because that path is the running gpk binary

the windows side already does the right dance (rename dest to .old, copy new into the freed path). this lifts that pattern to unix, gated on the initial rename failing so the same-filesystem case stays a single rename.

repro from the user that hit it:

\`\`\`
$ sudo gpk update
[sudo] password for carlos:
gpk v0.4.6 - checking for updates...
cannot replace binary: open /usr/bin/gpk: text file busy
\`\`\`

after the fix the same call:
- \`os.Rename\` fails as before (EXDEV)
- new branch: \`os.Rename(/usr/bin/gpk, /usr/bin/gpk.old)\` (succeeds, kernel keeps the inode alive for the running process)
- \`moveFile(src, /usr/bin/gpk)\` now sees a vacant dest and copies the new binary cleanly
- \`/usr/bin/gpk.old\` is unlinked; the running process keeps it open until exit, then it vanishes

three unit tests in \`internal/updater/replace_unix_test.go\`:
- same-filesystem fast path (the rename works, nothing else runs)
- cross-filesystem path (force the initial rename to fail via a renameFile var; verify dest gets the new content and .old is removed)
- cross-filesystem rollback (force the initial rename to fail and have src missing; verify dest is rolled back from .old)

## test plan
- [x] \`go test ./internal/updater/... -v\`
- [x] \`go test ./...\`
- [x] \`go vet ./...\`
- [x] \`go build ./cmd/gpk\`

worth shipping as v0.5.1. essentially every linux user who installed gpk to /usr/bin or any non-home location hits this; the only ones it doesn't hurt are those who installed under their home filesystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary update reliability on Unix systems with enhanced fallback strategies for cross-filesystem updates and rollback capability on failures

* **Tests**
  * Added comprehensive test coverage for fast-path updates, cross-filesystem scenarios, and error recovery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neur0map/glazepkg/pull/58)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->