### PR TITLE
Added scroll feature for better list rendering and user experience.

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -657,6 +657,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.tableHeight < 1 {
 			m.tableHeight = 1
 		}
+
+		// Clamp scroll and cursor on resize so cursor stays on screen
+		totalRows := len(m.filteredPkgs)
+		maxScroll := totalRows - m.tableHeight
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+		if m.scroll > maxScroll {
+			m.scroll = maxScroll
+		}
+		if totalRows > 0 && m.cursor >= totalRows {
+			m.cursor = totalRows - 1
+		}
+		if m.cursor < m.scroll {
+			m.cursor = m.scroll
+		}
+		if m.cursor >= m.scroll+m.tableHeight {
+			m.cursor = m.scroll + m.tableHeight - 1
+		}
 		return m, nil
 
 	case tea.KeyMsg:
@@ -1216,7 +1235,7 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "ctrl+d", "pgdown":
-		m.cursor += m.height / 2
+		m.cursor += max(m.tableHeight/2, 1)
 		if m.cursor >= len(m.filteredPkgs) {
 			m.cursor = len(m.filteredPkgs) - 1
 		}
@@ -1224,12 +1243,20 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 			m.scroll = m.cursor - m.tableHeight + 1
 		}
 	case "ctrl+u", "pgup":
-		m.cursor -= m.height / 2
+		m.cursor -= max(m.tableHeight/2, 1)
 		if m.cursor < 0 {
 			m.cursor = 0
 		}
 		if m.cursor < m.scroll {
 			m.scroll = m.cursor
+		}
+	case "z":
+		m.scroll = m.cursor - m.tableHeight/2
+		if m.scroll > len(m.filteredPkgs)-m.tableHeight {
+			m.scroll = len(m.filteredPkgs) - m.tableHeight
+		}
+		if m.scroll < 0 {
+			m.scroll = 0
 		}
 	case "enter":
 		if len(m.filteredPkgs) > 0 && m.cursor < len(m.filteredPkgs) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -193,6 +193,8 @@ type Model struct {
 	activeTab    int
 	cursor       int
 	scroll       int
+	topScrollOff int
+	botScrollOff int
 	tableHeight  int // number of list elements displayed
 	view         view
 	scanning     bool
@@ -643,39 +645,45 @@ func doExport(pkgs []model.Package, format int) tea.Cmd {
 	}
 }
 
+func (m Model) calculateScroll() int {
+	new_scroll := m.scroll
+
+	if m.cursor-m.scroll >= m.botScrollOff {
+		new_scroll = min(m.cursor - m.botScrollOff + 1, len(m.filteredPkgs) - m.tableHeight)
+	} else if m.cursor-m.scroll <= m.topScrollOff {
+		new_scroll = max(0, m.cursor-m.topScrollOff)
+	}
+
+	new_scroll = min(new_scroll, len(m.filteredPkgs) - m.tableHeight)
+	new_scroll = max(0, new_scroll)
+
+	return new_scroll
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		// Note for @neur0map : this used to be height - 14 which got passed to a function which just subtracted 4 more
-		// The initial 'height - 14' had this comment right above it, so I'll leave it here for you to update accordingly, since I don't understand the additional '- 4'
-
 		// Package table. Height budget accounts for: header(2) + summary(1) +
-		// blank(1) + tabs(2) + panel chrome(4) + separator(1) + status(2)
+		// blank(1) + tabs(2) + panel chrome(4) + separator(1) + status(2) - 4?
 		m.tableHeight = m.height - 18
-		if m.tableHeight < 1 {
-			m.tableHeight = 1
+		if m.tableHeight < 5 {
+			m.tableHeight = 5
 		}
 
-		// Clamp scroll and cursor on resize so cursor stays on screen
-		totalRows := len(m.filteredPkgs)
-		maxScroll := totalRows - m.tableHeight
-		if maxScroll < 0 {
-			maxScroll = 0
+		tableCenter := m.tableHeight / 2
+		m.topScrollOff = tableCenter - 4
+		m.botScrollOff = tableCenter + 5
+		if m.tableHeight % 2 == 0 {
+			m.botScrollOff -= 1
 		}
-		if m.scroll > maxScroll {
-			m.scroll = maxScroll
-		}
-		if totalRows > 0 && m.cursor >= totalRows {
-			m.cursor = totalRows - 1
-		}
-		if m.cursor < m.scroll {
-			m.cursor = m.scroll
-		}
-		if m.cursor >= m.scroll+m.tableHeight {
-			m.cursor = m.scroll + m.tableHeight - 1
-		}
+
+		m.topScrollOff = max(m.topScrollOff, 0)
+		m.botScrollOff = min(m.botScrollOff, m.tableHeight)
+
+		m.scroll = m.calculateScroll()
+
 		return m, nil
 
 	case tea.KeyMsg:
@@ -1193,36 +1201,12 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 		if m.cursor < len(m.filteredPkgs)-1 {
 			m.cursor++
 		}
-		if m.cursor >= m.scroll+m.tableHeight {
-			m.scroll = m.cursor - m.tableHeight + 1
-		}
+		m.scroll = m.calculateScroll()
 	case "k", "up":
 		if m.cursor > 0 {
 			m.cursor--
 		}
-		if m.cursor < m.scroll {
-			m.scroll = m.cursor
-		}
-	case "ctrl+e":
-		m.scroll += 1
-		maxScroll := len(m.filteredPkgs) - m.tableHeight
-		if maxScroll < 0 {
-			maxScroll = 0
-		}
-		if m.scroll > maxScroll {
-			m.scroll = maxScroll
-		}
-		if m.scroll > m.cursor {
-			m.cursor = m.scroll
-		}
-	case "ctrl+y":
-		m.scroll -= 1
-		if m.scroll < 0 {
-			m.scroll = 0
-		}
-		if m.scroll+m.tableHeight <= m.cursor {
-			m.cursor = m.scroll + m.tableHeight - 1
-		}
+		m.scroll = m.calculateScroll()
 	case "g", "home":
 		m.cursor = 0
 		m.scroll = 0
@@ -1239,17 +1223,13 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 		if m.cursor >= len(m.filteredPkgs) {
 			m.cursor = len(m.filteredPkgs) - 1
 		}
-		if m.cursor >= m.scroll+m.tableHeight {
-			m.scroll = m.cursor - m.tableHeight + 1
-		}
+		m.scroll = m.calculateScroll()
 	case "ctrl+u", "pgup":
 		m.cursor -= max(m.tableHeight/2, 1)
 		if m.cursor < 0 {
 			m.cursor = 0
 		}
-		if m.cursor < m.scroll {
-			m.scroll = m.cursor
-		}
+		m.scroll = m.calculateScroll()
 	case "z":
 		m.scroll = m.cursor - m.tableHeight/2
 		if m.scroll > len(m.filteredPkgs)-m.tableHeight {
@@ -1611,10 +1591,6 @@ func (m Model) renderListView(b *strings.Builder) {
 		return
 	}
 
-	// listHeight := m.height - 14
-	// if listHeight < 5 {
-	// 	listHeight = 5
-	// }
 	showSize := m.sizeFilter > 0 && sizeFilters[m.sizeFilter].MinBytes != -1
 	panelContent.WriteString(renderPackageTable(m.filteredPkgs, m.cursor, m.scroll, m.tableHeight, innerW+2, showSize, m.upgradingPkgName, m.removingPkgName, m.selections))
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -193,6 +193,7 @@ type Model struct {
 	activeTab    int
 	cursor       int
 	scroll       int
+	tableHeight  int // number of list elements displayed
 	view         view
 	scanning     bool
 	statusMsg    string
@@ -647,6 +648,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		// Note for @neur0map : this used to be height - 14 which got passed to a function which just subtracted 4 more
+		// The initial 'height - 14' had this comment right above it, so I'll leave it here for you to update accordingly, since I don't understand the additional '- 4'
+
+		// Package table. Height budget accounts for: header(2) + summary(1) +
+		// blank(1) + tabs(2) + panel chrome(4) + separator(1) + status(2)
+		m.tableHeight = m.height - 18
+		if m.tableHeight < 1 {
+			m.tableHeight = 1
+		}
 		return m, nil
 
 	case tea.KeyMsg:
@@ -1164,10 +1174,8 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 		if m.cursor < len(m.filteredPkgs)-1 {
 			m.cursor++
 		}
-		listHeight := m.height - 14 // WARNING: copied over from renderListView
-		visibleHeight := listHeight - 4 // WARNING: copied over from table.go
-		if m.cursor >= m.scroll + visibleHeight {
-			m.scroll = m.cursor - visibleHeight + 1
+		if m.cursor >= m.scroll+m.tableHeight {
+			m.scroll = m.cursor - m.tableHeight + 1
 		}
 	case "k", "up":
 		if m.cursor > 0 {
@@ -1178,9 +1186,7 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 		}
 	case "ctrl+e":
 		m.scroll += 1
-		listHeight := m.height - 14 // WARNING: copied over from renderListView
-		visibleHeight := listHeight - 4 // WARNING: copied over from table.go
-		maxScroll := len(m.filteredPkgs) - visibleHeight
+		maxScroll := len(m.filteredPkgs) - m.tableHeight
 		if maxScroll < 0 {
 			maxScroll = 0
 		}
@@ -1195,10 +1201,8 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 		if m.scroll < 0 {
 			m.scroll = 0
 		}
-		listHeight := m.height - 14 // WARNING: copied over from render list view
-		visibleHeight := listHeight - 4 // WARNING: copied over from table.go
-		if m.scroll + visibleHeight <= m.cursor {
-			m.cursor = m.scroll + visibleHeight - 1
+		if m.scroll+m.tableHeight <= m.cursor {
+			m.cursor = m.scroll + m.tableHeight - 1
 		}
 	case "g", "home":
 		m.cursor = 0
@@ -1206,9 +1210,7 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 	case "G", "end":
 		if len(m.filteredPkgs) > 0 {
 			m.cursor = len(m.filteredPkgs) - 1
-			listHeight := m.height - 14 // WARNING: copied over from render list view
-			visibleHeight := listHeight - 4 // WARNING: copied over from table.go
-			m.scroll = len(m.filteredPkgs) - visibleHeight
+			m.scroll = len(m.filteredPkgs) - m.tableHeight
 			if m.scroll < 0 {
 				m.scroll = 0
 			}
@@ -1218,10 +1220,8 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 		if m.cursor >= len(m.filteredPkgs) {
 			m.cursor = len(m.filteredPkgs) - 1
 		}
-		listHeight := m.height - 14 // WARNING: copied over from renderListView
-		visibleHeight := listHeight - 4 // WARNING: copied over from table.go
-		if m.cursor >= m.scroll + visibleHeight {
-			m.scroll = m.cursor - visibleHeight + 1
+		if m.cursor >= m.scroll+m.tableHeight {
+			m.scroll = m.cursor - m.tableHeight + 1
 		}
 	case "ctrl+u", "pgup":
 		m.cursor -= m.height / 2
@@ -1416,10 +1416,8 @@ func (m *Model) applyFilter() {
 	// if m.cursor >= len(m.filteredPkgs) {
 	// 	m.cursor = max(0, len(m.filteredPkgs)-1)
 	// }
-	listHeight := m.height - 14 // WARNING: copied over from renderListView
-	visibleHeight := listHeight - 4 // WARNING: copied over from table.go
-	if m.scroll + visibleHeight > len(m.filteredPkgs) {
-		m.scroll = len(m.filteredPkgs) - listHeight + 1
+	if m.scroll+m.tableHeight > len(m.filteredPkgs) {
+		m.scroll = len(m.filteredPkgs) - m.tableHeight + 1
 	}
 	if m.scroll < 0 {
 		m.scroll = 0
@@ -1427,8 +1425,8 @@ func (m *Model) applyFilter() {
 	if m.cursor < m.scroll {
 		m.cursor = m.scroll
 	}
-	if m.cursor >= m.scroll + visibleHeight {
-		m.scroll = m.cursor - visibleHeight + 1
+	if m.cursor >= m.scroll+m.tableHeight {
+		m.scroll = m.cursor - m.tableHeight + 1
 	}
 }
 
@@ -1586,14 +1584,12 @@ func (m Model) renderListView(b *strings.Builder) {
 		return
 	}
 
-	// Package table. Height budget accounts for: header(2) + summary(1) +
-	// blank(1) + tabs(2) + panel chrome(4) + separator(1) + status(2).
-	listHeight := m.height - 14
-	if listHeight < 5 {
-		listHeight = 5
-	}
+	// listHeight := m.height - 14
+	// if listHeight < 5 {
+	// 	listHeight = 5
+	// }
 	showSize := m.sizeFilter > 0 && sizeFilters[m.sizeFilter].MinBytes != -1
-	panelContent.WriteString(renderPackageTable(m.filteredPkgs, m.cursor, m.scroll, listHeight, innerW+2, showSize, m.upgradingPkgName, m.removingPkgName, m.selections))
+	panelContent.WriteString(renderPackageTable(m.filteredPkgs, m.cursor, m.scroll, m.tableHeight, innerW+2, showSize, m.upgradingPkgName, m.removingPkgName, m.selections))
 
 	// Loading indicators, inside the panel so they don't break the frame.
 	if m.loadingDescs {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -192,6 +192,7 @@ type Model struct {
 	tabs         []tabItem
 	activeTab    int
 	cursor       int
+	scroll       int
 	view         view
 	scanning     bool
 	statusMsg    string
@@ -1092,7 +1093,12 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		default:
 			var cmd tea.Cmd
+			prev := m.filterInput.Value()
 			m.filterInput, cmd = m.filterInput.Update(msg)
+			if m.filterInput.Value() != prev {
+				m.scroll = 0
+				m.cursor = 0
+			}
 			m.applyFilter()
 			return m, cmd
 		}
@@ -1141,6 +1147,7 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 		}
 		m.activeTab = (m.activeTab + 1) % len(m.tabs)
 		m.cursor = 0
+		m.scroll = 0
 		m.applyFilter()
 	case "shift+tab":
 		if len(m.tabs) == 0 {
@@ -1151,30 +1158,78 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 			m.activeTab = len(m.tabs) - 1
 		}
 		m.cursor = 0
+		m.scroll = 0
 		m.applyFilter()
 	case "j", "down":
 		if m.cursor < len(m.filteredPkgs)-1 {
 			m.cursor++
 		}
+		listHeight := m.height - 14 // WARNING: copied over from renderListView
+		visibleHeight := listHeight - 4 // WARNING: copied over from table.go
+		if m.cursor >= m.scroll + visibleHeight {
+			m.scroll = m.cursor - visibleHeight + 1
+		}
 	case "k", "up":
 		if m.cursor > 0 {
 			m.cursor--
 		}
+		if m.cursor < m.scroll {
+			m.scroll = m.cursor
+		}
+	case "ctrl+e":
+		m.scroll += 1
+		listHeight := m.height - 14 // WARNING: copied over from renderListView
+		visibleHeight := listHeight - 4 // WARNING: copied over from table.go
+		maxScroll := len(m.filteredPkgs) - visibleHeight
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+		if m.scroll > maxScroll {
+			m.scroll = maxScroll
+		}
+		if m.scroll > m.cursor {
+			m.cursor = m.scroll
+		}
+	case "ctrl+y":
+		m.scroll -= 1
+		if m.scroll < 0 {
+			m.scroll = 0
+		}
+		listHeight := m.height - 14 // WARNING: copied over from render list view
+		visibleHeight := listHeight - 4 // WARNING: copied over from table.go
+		if m.scroll + visibleHeight <= m.cursor {
+			m.cursor = m.scroll + visibleHeight - 1
+		}
 	case "g", "home":
 		m.cursor = 0
+		m.scroll = 0
 	case "G", "end":
 		if len(m.filteredPkgs) > 0 {
 			m.cursor = len(m.filteredPkgs) - 1
+			listHeight := m.height - 14 // WARNING: copied over from render list view
+			visibleHeight := listHeight - 4 // WARNING: copied over from table.go
+			m.scroll = len(m.filteredPkgs) - visibleHeight
+			if m.scroll < 0 {
+				m.scroll = 0
+			}
 		}
 	case "ctrl+d", "pgdown":
 		m.cursor += m.height / 2
 		if m.cursor >= len(m.filteredPkgs) {
 			m.cursor = len(m.filteredPkgs) - 1
 		}
+		listHeight := m.height - 14 // WARNING: copied over from renderListView
+		visibleHeight := listHeight - 4 // WARNING: copied over from table.go
+		if m.cursor >= m.scroll + visibleHeight {
+			m.scroll = m.cursor - visibleHeight + 1
+		}
 	case "ctrl+u", "pgup":
 		m.cursor -= m.height / 2
 		if m.cursor < 0 {
 			m.cursor = 0
+		}
+		if m.cursor < m.scroll {
+			m.scroll = m.cursor
 		}
 	case "enter":
 		if len(m.filteredPkgs) > 0 && m.cursor < len(m.filteredPkgs) {
@@ -1358,8 +1413,22 @@ func (m *Model) applyFilter() {
 	// Then apply ranked search (name prefix > name contains > description, with fuzzy fallback)
 	m.filteredPkgs = rankPackages(tabFiltered, query)
 
-	if m.cursor >= len(m.filteredPkgs) {
-		m.cursor = max(0, len(m.filteredPkgs)-1)
+	// if m.cursor >= len(m.filteredPkgs) {
+	// 	m.cursor = max(0, len(m.filteredPkgs)-1)
+	// }
+	listHeight := m.height - 14 // WARNING: copied over from renderListView
+	visibleHeight := listHeight - 4 // WARNING: copied over from table.go
+	if m.scroll + visibleHeight > len(m.filteredPkgs) {
+		m.scroll = len(m.filteredPkgs) - listHeight + 1
+	}
+	if m.scroll < 0 {
+		m.scroll = 0
+	}
+	if m.cursor < m.scroll {
+		m.cursor = m.scroll
+	}
+	if m.cursor >= m.scroll + visibleHeight {
+		m.scroll = m.cursor - visibleHeight + 1
 	}
 }
 
@@ -1524,7 +1593,7 @@ func (m Model) renderListView(b *strings.Builder) {
 		listHeight = 5
 	}
 	showSize := m.sizeFilter > 0 && sizeFilters[m.sizeFilter].MinBytes != -1
-	panelContent.WriteString(renderPackageTable(m.filteredPkgs, m.cursor, listHeight, innerW+2, showSize, m.upgradingPkgName, m.removingPkgName, m.selections))
+	panelContent.WriteString(renderPackageTable(m.filteredPkgs, m.cursor, m.scroll, listHeight, innerW+2, showSize, m.upgradingPkgName, m.removingPkgName, m.selections))
 
 	// Loading indicators, inside the panel so they don't break the frame.
 	if m.loadingDescs {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1412,9 +1412,9 @@ func (m *Model) applyFilter() {
 	// Then apply ranked search (name prefix > name contains > description, with fuzzy fallback)
 	m.filteredPkgs = rankPackages(tabFiltered, query)
 
-	// if m.cursor >= len(m.filteredPkgs) {
-	// 	m.cursor = max(0, len(m.filteredPkgs)-1)
-	// }
+	if m.cursor >= len(m.filteredPkgs) {
+		m.cursor = max(0, len(m.filteredPkgs)-1)
+	}
 	if m.scroll+m.tableHeight > len(m.filteredPkgs) {
 		m.scroll = len(m.filteredPkgs) - m.tableHeight + 1
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1221,7 +1221,7 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 	case "ctrl+d", "pgdown":
 		m.cursor += max(m.tableHeight/2, 1)
 		if m.cursor >= len(m.filteredPkgs) {
-			m.cursor = len(m.filteredPkgs) - 1
+			m.cursor = max(0, len(m.filteredPkgs)-1)
 		}
 		m.scroll = m.calculateScroll()
 	case "ctrl+u", "pgup":
@@ -1230,14 +1230,6 @@ func (m *Model) handleListKey(key string) (tea.Model, tea.Cmd) {
 			m.cursor = 0
 		}
 		m.scroll = m.calculateScroll()
-	case "z":
-		m.scroll = m.cursor - m.tableHeight/2
-		if m.scroll > len(m.filteredPkgs)-m.tableHeight {
-			m.scroll = len(m.filteredPkgs) - m.tableHeight
-		}
-		if m.scroll < 0 {
-			m.scroll = 0
-		}
 	case "enter":
 		if len(m.filteredPkgs) > 0 && m.cursor < len(m.filteredPkgs) {
 			pkg := m.filteredPkgs[m.cursor]

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -33,6 +33,7 @@ type KeyMap struct {
 	ScrollDown  key.Binding
 	HalfPageUp  key.Binding
 	HalfPageDn  key.Binding
+	Center      key.Binding
 	Home        key.Binding
 	End         key.Binding
 }
@@ -153,6 +154,10 @@ var Keys = KeyMap{
 	HalfPageUp: key.NewBinding(
 		key.WithKeys("ctrl+u"),
 		key.WithHelp("ctrl+u", "½ page up"),
+	),
+	Center: key.NewBinding(
+		key.WithKeys("z"),
+		key.WithHelp("z", "center cursor"),
 	),
 	HalfPageDn: key.NewBinding(
 		key.WithKeys("ctrl+d"),

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -29,6 +29,8 @@ type KeyMap struct {
 	Down        key.Binding
 	PageUp      key.Binding
 	PageDown    key.Binding
+	ScrollUp    key.Binding
+	ScrollDown  key.Binding
 	HalfPageUp  key.Binding
 	HalfPageDn  key.Binding
 	Home        key.Binding
@@ -132,13 +134,21 @@ var Keys = KeyMap{
 		key.WithKeys("down", "j"),
 		key.WithHelp("↓/j", "down"),
 	),
-	PageUp: key.NewBinding(
+	PageUp: key.NewBinding( // NOTE: not sure why this is here, the implementation is so that pgup is same as ctrl+u (1/2 page up)
 		key.WithKeys("pgup"),
 		key.WithHelp("pgup", "page up"),
 	),
 	PageDown: key.NewBinding(
 		key.WithKeys("pgdown"),
 		key.WithHelp("pgdn", "page down"),
+	),
+	ScrollUp: key.NewBinding(
+		key.WithKeys("ctrl+y"),
+		key.WithHelp("ctrl+y", "scroll up"),
+	),
+	ScrollDown: key.NewBinding(
+		key.WithKeys("ctrl+e"),
+		key.WithHelp("ctrl+e", "scroll down"),
 	),
 	HalfPageUp: key.NewBinding(
 		key.WithKeys("ctrl+u"),

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -29,11 +29,8 @@ type KeyMap struct {
 	Down        key.Binding
 	PageUp      key.Binding
 	PageDown    key.Binding
-	ScrollUp    key.Binding
-	ScrollDown  key.Binding
 	HalfPageUp  key.Binding
 	HalfPageDn  key.Binding
-	Center      key.Binding
 	Home        key.Binding
 	End         key.Binding
 }
@@ -143,21 +140,9 @@ var Keys = KeyMap{
 		key.WithKeys("pgdown"),
 		key.WithHelp("pgdn", "page down"),
 	),
-	ScrollUp: key.NewBinding(
-		key.WithKeys("ctrl+y"),
-		key.WithHelp("ctrl+y", "scroll up"),
-	),
-	ScrollDown: key.NewBinding(
-		key.WithKeys("ctrl+e"),
-		key.WithHelp("ctrl+e", "scroll down"),
-	),
 	HalfPageUp: key.NewBinding(
 		key.WithKeys("ctrl+u"),
 		key.WithHelp("ctrl+u", "½ page up"),
-	),
-	Center: key.NewBinding(
-		key.WithKeys("z"),
-		key.WithHelp("z", "center cursor"),
 	),
 	HalfPageDn: key.NewBinding(
 		key.WithKeys("ctrl+d"),

--- a/internal/ui/scroll_test.go
+++ b/internal/ui/scroll_test.go
@@ -320,3 +320,42 @@ func TestWindowResize_EmptyListNoPanic(t *testing.T) {
 		t.Errorf("empty list: scroll=%d cursor=%d, want 0/0", m2.scroll, m2.cursor)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// applyFilter
+// ---------------------------------------------------------------------------
+
+func TestApplyFilter_CursorClampedWhenListShrinks(t *testing.T) {
+	// cursor beyond the new filteredPkgs length must be pulled to the last item,
+	// not left out of range where renderPackageTable would crash.
+	pkgs := makePkgs(10)
+	m := &Model{
+		allPkgs:      pkgs,
+		filteredPkgs: pkgs,
+		tableHeight:  20,
+		cursor:       8,
+		scroll:       0,
+	}
+	m.tabs = buildTabs(pkgs)
+	// Swap in a shorter slice directly (simulates a filter narrowing results).
+	m.filteredPkgs = pkgs[:3]
+	m.applyFilter()
+	if m.cursor >= len(m.filteredPkgs) {
+		t.Errorf("cursor %d out of range, filteredPkgs len = %d", m.cursor, len(m.filteredPkgs))
+	}
+}
+
+func TestApplyFilter_CursorAndScrollBothValidOnEmptyResult(t *testing.T) {
+	// No packages at all — filteredPkgs will be empty after applyFilter.
+	m := &Model{
+		allPkgs:     nil,
+		tableHeight: 20,
+		cursor:      4,
+		scroll:      0,
+	}
+	m.tabs = buildTabs(nil)
+	m.applyFilter()
+	if m.cursor != 0 || m.scroll != 0 {
+		t.Errorf("empty result: cursor=%d scroll=%d, want 0/0", m.cursor, m.scroll)
+	}
+}

--- a/internal/ui/scroll_test.go
+++ b/internal/ui/scroll_test.go
@@ -18,7 +18,7 @@ func makePkgs(n int) []model.Package {
 }
 
 // scrollModel builds a Model with the scroll offsets that WindowSizeMsg would
-// compute for the given tableHeight, mimicing produciton
+// compute for the given tableHeight, mimicing production
 func scrollModel(tableHeight, scroll, cursor, numPkgs int) *Model {
 	m := &Model{
 		filteredPkgs: makePkgs(numPkgs),

--- a/internal/ui/scroll_test.go
+++ b/internal/ui/scroll_test.go
@@ -1,0 +1,322 @@
+package ui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/neur0map/glazepkg/internal/model"
+)
+
+// makePkgs returns n dummy packages for scroll tests.
+func makePkgs(n int) []model.Package {
+	pkgs := make([]model.Package, n)
+	for i := range pkgs {
+		pkgs[i] = model.Package{Name: fmt.Sprintf("pkg-%d", i)}
+	}
+	return pkgs
+}
+
+// scrollModel builds a Model with the scroll offsets that WindowSizeMsg would
+// compute for the given tableHeight, mimicing produciton
+func scrollModel(tableHeight, scroll, cursor, numPkgs int) *Model {
+	m := &Model{
+		filteredPkgs: makePkgs(numPkgs),
+		tableHeight:  tableHeight,
+		scroll:       scroll,
+		cursor:       cursor,
+	}
+	tc := tableHeight / 2
+	m.topScrollOff = tc - 4
+	m.botScrollOff = tc + 5
+	if tableHeight%2 == 0 {
+		m.botScrollOff--
+	}
+	if m.topScrollOff < 0 {
+		m.topScrollOff = 0
+	}
+	if m.botScrollOff > tableHeight {
+		m.botScrollOff = tableHeight
+	}
+	return m
+}
+
+func runeKey(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+// ---------------------------------------------------------------------------
+// calculateScroll
+// ---------------------------------------------------------------------------
+
+func TestCalculateScroll_CursorInMiddleIsNoop(t *testing.T) {
+	// cursor well inside [topScrollOff, botScrollOff) - scroll must not change.
+	m := scrollModel(20, 0, 10, 30)
+	if got := m.calculateScroll(); got != 0 {
+		t.Errorf("scroll = %d, want 0", got)
+	}
+}
+
+func TestCalculateScroll_CursorAtBotThresholdAdvancesScroll(t *testing.T) {
+	// cursor-scroll == botScrollOff triggers a downward scroll.
+	m := scrollModel(20, 0, 0, 30)
+	m.cursor = m.scroll + m.botScrollOff
+	got := m.calculateScroll()
+	if got <= 0 {
+		t.Errorf("expected scroll > 0 when cursor at botScrollOff, got %d", got)
+	}
+}
+
+func TestCalculateScroll_CursorInsideTopDeadZoneRetreatsScroll(t *testing.T) {
+	// cursor-scroll < topScrollOff triggers an upward scroll.
+	m := scrollModel(20, 10, 0, 30)
+	m.cursor = m.scroll + m.topScrollOff - 1 // one inside the dead zone
+	initialScroll := m.scroll
+	got := m.calculateScroll()
+	if got >= initialScroll {
+		t.Errorf("expected scroll to retreat from %d, got %d", initialScroll, got)
+	}
+}
+
+func TestCalculateScroll_ResultNeverNegative(t *testing.T) {
+	// cursor at row 0 with topScrollOff > 0 would produce negative scroll without the clamp.
+	m := scrollModel(20, 0, 0, 30)
+	if got := m.calculateScroll(); got < 0 {
+		t.Errorf("scroll = %d, must not be negative", got)
+	}
+}
+
+func TestCalculateScroll_ResultNeverExceedsMaxScroll(t *testing.T) {
+	// cursor at last item - scroll must not exceed len-tableHeight.
+	m := scrollModel(20, 0, 0, 30)
+	m.cursor = len(m.filteredPkgs) - 1
+	got := m.calculateScroll()
+	maxScroll := len(m.filteredPkgs) - m.tableHeight
+	if got > maxScroll {
+		t.Errorf("scroll = %d, exceeds maxScroll %d", got, maxScroll)
+	}
+}
+
+func TestCalculateScroll_EmptyListNoPanic(t *testing.T) {
+	m := scrollModel(20, 0, 0, 0)
+	got := m.calculateScroll()
+	if got != 0 {
+		t.Errorf("empty list: scroll = %d, want 0", got)
+	}
+}
+
+func TestCalculateScroll_ShortListReturnsZero(t *testing.T) {
+	// List shorter than viewport - maxScroll is negative, result must be 0.
+	m := scrollModel(20, 0, 2, 5)
+	got := m.calculateScroll()
+	if got != 0 {
+		t.Errorf("short list: scroll = %d, want 0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// j / k navigation
+// ---------------------------------------------------------------------------
+
+func TestJKey_CursorAdvances(t *testing.T) {
+	m := scrollModel(20, 0, 0, 10)
+	_, _ = m.handleKey(runeKey("j"))
+	if m.cursor != 1 {
+		t.Errorf("cursor = %d, want 1", m.cursor)
+	}
+}
+
+func TestJKey_CursorClampsAtLastItem(t *testing.T) {
+	m := scrollModel(20, 0, 9, 10)
+	_, _ = m.handleKey(runeKey("j"))
+	if m.cursor != 9 {
+		t.Errorf("cursor = %d, want 9 (last item)", m.cursor)
+	}
+}
+
+func TestJKey_EmptyListNoPanic(t *testing.T) {
+	m := scrollModel(20, 0, 0, 0)
+	_, _ = m.handleKey(runeKey("j"))
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0 on empty list", m.cursor)
+	}
+}
+
+func TestJKey_ScrollAdvancesAfterCursorPassesBotScrollOff(t *testing.T) {
+	m := scrollModel(20, 0, 0, 40)
+	// Press j until cursor is one past botScrollOff - scroll must advance.
+	for range m.botScrollOff + 1 {
+		_, _ = m.handleKey(runeKey("j"))
+	}
+	if m.scroll == 0 {
+		t.Errorf("scroll stayed 0 after cursor passed botScrollOff (%d)", m.botScrollOff)
+	}
+}
+
+func TestKKey_CursorRetreats(t *testing.T) {
+	m := scrollModel(20, 0, 5, 10)
+	_, _ = m.handleKey(runeKey("k"))
+	if m.cursor != 4 {
+		t.Errorf("cursor = %d, want 4", m.cursor)
+	}
+}
+
+func TestKKey_CursorClampsAtZero(t *testing.T) {
+	m := scrollModel(20, 0, 0, 10)
+	_, _ = m.handleKey(runeKey("k"))
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0", m.cursor)
+	}
+}
+
+func TestKKey_EmptyListNoPanic(t *testing.T) {
+	m := scrollModel(20, 0, 0, 0)
+	_, _ = m.handleKey(runeKey("k"))
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0 on empty list", m.cursor)
+	}
+}
+
+func TestKKey_ScrollRetreatsWhenCursorEntersTopDeadZone(t *testing.T) {
+	// Place cursor exactly at the top-dead-zone boundary, then press k to
+	// enter the zone - scroll must retreat.
+	m := scrollModel(20, 10, 0, 40)
+	m.cursor = m.scroll + m.topScrollOff // cursor-scroll == topScrollOff: at boundary
+	initialScroll := m.scroll
+	_, _ = m.handleKey(runeKey("k")) // cursor-scroll drops to topScrollOff-1: inside zone
+	if m.scroll >= initialScroll {
+		t.Errorf("scroll = %d, expected retreat from %d", m.scroll, initialScroll)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ctrl+d / ctrl+u - half-page cursor jump (scroll follows via calculateScroll)
+// ---------------------------------------------------------------------------
+
+func TestCtrlD_CursorAdvancesByHalfTableHeight(t *testing.T) {
+	// Starting well below botScrollOff so calculateScroll doesn't fire yet.
+	m := scrollModel(20, 0, 0, 40)
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	want := m.tableHeight / 2
+	if m.cursor != want {
+		t.Errorf("cursor = %d, want %d", m.cursor, want)
+	}
+}
+
+func TestCtrlD_CursorClampsAtLastItem(t *testing.T) {
+	m := scrollModel(20, 0, 35, 40)
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	if m.cursor != 39 {
+		t.Errorf("cursor = %d, want 39 (last item)", m.cursor)
+	}
+}
+
+func TestCtrlD_ScrollStaysInBounds(t *testing.T) {
+	// Mash ctrl+d repeatedly - scroll must never exceed maxScroll.
+	m := scrollModel(20, 0, 0, 40)
+	for range 10 {
+		_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	}
+	maxScroll := len(m.filteredPkgs) - m.tableHeight
+	if m.scroll < 0 || m.scroll > maxScroll {
+		t.Errorf("scroll %d out of range [0, %d]", m.scroll, maxScroll)
+	}
+}
+
+func TestCtrlD_EmptyListNoPanic(t *testing.T) {
+	m := scrollModel(20, 0, 0, 0)
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	if m.scroll != 0 || m.cursor != 0 {
+		t.Errorf("empty list: scroll=%d cursor=%d, want 0/0", m.scroll, m.cursor)
+	}
+}
+
+func TestCtrlU_CursorRetreats(t *testing.T) {
+	m := scrollModel(20, 0, 20, 40)
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlU})
+	want := 20 - m.tableHeight/2
+	if m.cursor != want {
+		t.Errorf("cursor = %d, want %d", m.cursor, want)
+	}
+}
+
+func TestCtrlU_CursorClampsAtZero(t *testing.T) {
+	m := scrollModel(20, 0, 5, 40)
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlU})
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0", m.cursor)
+	}
+}
+
+func TestCtrlU_ScrollStaysInBounds(t *testing.T) {
+	// Mash ctrl+u from a high scroll position - scroll must never go negative.
+	m := scrollModel(20, 15, 25, 40)
+	for range 10 {
+		_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlU})
+	}
+	if m.scroll < 0 {
+		t.Errorf("scroll = %d, must not be negative", m.scroll)
+	}
+}
+
+func TestCtrlU_EmptyListNoPanic(t *testing.T) {
+	m := scrollModel(20, 0, 0, 0)
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlU})
+	if m.scroll != 0 || m.cursor != 0 {
+		t.Errorf("empty list: scroll=%d cursor=%d, want 0/0", m.scroll, m.cursor)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Window resize
+// ---------------------------------------------------------------------------
+
+func TestWindowResize_OffsetsDerivedFromPostFloorTableHeight(t *testing.T) {
+	// height=20 → height-18=2, floored to 5. Offsets must be computed from 5,
+	// not 2; otherwise botScrollOff gets clamped to 2 and the cursor soft-locks.
+	m := Model{}
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
+	m2 := result.(Model)
+	if m2.tableHeight != 5 {
+		t.Fatalf("tableHeight = %d, want 5", m2.tableHeight)
+	}
+	if m2.topScrollOff < 0 {
+		t.Errorf("topScrollOff = %d, must not be negative", m2.topScrollOff)
+	}
+	if m2.botScrollOff > m2.tableHeight {
+		t.Errorf("botScrollOff %d > tableHeight %d", m2.botScrollOff, m2.tableHeight)
+	}
+}
+
+func TestWindowResize_ScrollReclampedWhenWindowGrows(t *testing.T) {
+	// 15 packages, scroll=10. Resize so tableHeight=12 → maxScroll=3; scroll
+	// must be pulled down so the last page is filled instead of left empty.
+	pkgs := makePkgs(15)
+	m := Model{filteredPkgs: pkgs, scroll: 10, cursor: 10, tableHeight: 5}
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30}) // height-18=12
+	m2 := result.(Model)
+	maxScroll := len(pkgs) - m2.tableHeight
+	if m2.scroll > maxScroll {
+		t.Errorf("scroll = %d, exceeds maxScroll %d after window grew", m2.scroll, maxScroll)
+	}
+}
+
+func TestWindowResize_CursorPulledIntoViewport(t *testing.T) {
+	// cursor beyond the new viewport bottom must be clamped in.
+	pkgs := makePkgs(30)
+	m := Model{filteredPkgs: pkgs, scroll: 0, cursor: 25, tableHeight: 30}
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 26}) // height-18=8
+	m2 := result.(Model)
+	if m2.cursor >= m2.scroll+m2.tableHeight {
+		t.Errorf("cursor %d outside viewport [%d, %d)", m2.cursor, m2.scroll, m2.scroll+m2.tableHeight)
+	}
+}
+
+func TestWindowResize_EmptyListNoPanic(t *testing.T) {
+	m := Model{}
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	m2 := result.(Model)
+	if m2.scroll != 0 || m2.cursor != 0 {
+		t.Errorf("empty list: scroll=%d cursor=%d, want 0/0", m2.scroll, m2.cursor)
+	}
+}

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -12,7 +12,7 @@ import (
 
 const badgeWidth = 8 // fixed visual width for all manager badges
 
-func renderPackageTable(pkgs []model.Package, cursor, height, width int, showSize bool, upgradingPkg, removingPkg string, selections map[string]bool) string {
+func renderPackageTable(pkgs []model.Package, cursor, scroll, height, width int, showSize bool, upgradingPkg, removingPkg string, selections map[string]bool) string {
 	if len(pkgs) == 0 {
 		return StyleDim.Render("\n  No packages found.")
 	}
@@ -56,10 +56,7 @@ func renderPackageTable(pkgs []model.Package, cursor, height, width int, showSiz
 		visibleHeight = 1
 	}
 
-	start := 0
-	if cursor >= visibleHeight {
-		start = cursor - visibleHeight + 1
-	}
+	start := scroll
 	end := start + visibleHeight
 	if end > len(pkgs) {
 		end = len(pkgs)
@@ -194,7 +191,7 @@ func renderPackageTable(pkgs []model.Package, cursor, height, width int, showSiz
 	// Scroll indicator
 	total := len(pkgs)
 	if total > visibleHeight {
-		pct := (cursor + 1) * 100 / total
+		pct := (scroll + 1) * 100 / total
 		indicator := fmt.Sprintf("  %d/%d (%d%%)", cursor+1, total, pct)
 		lines = append(lines, StyleDim.Render(indicator))
 	}

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -12,7 +12,7 @@ import (
 
 const badgeWidth = 8 // fixed visual width for all manager badges
 
-func renderPackageTable(pkgs []model.Package, cursor, scroll, height, width int, showSize bool, upgradingPkg, removingPkg string, selections map[string]bool) string {
+func renderPackageTable(pkgs []model.Package, cursor, scroll, tableHeight, width int, showSize bool, upgradingPkg, removingPkg string, selections map[string]bool) string {
 	if len(pkgs) == 0 {
 		return StyleDim.Render("\n  No packages found.")
 	}
@@ -51,13 +51,12 @@ func renderPackageTable(pkgs []model.Package, cursor, scroll, height, width int,
 		StyleTableHeader.Render(lastCol)
 
 	// Scrolling viewport
-	visibleHeight := height - 4
-	if visibleHeight < 1 {
-		visibleHeight = 1
+	if tableHeight < 1 {
+		tableHeight = 1
 	}
 
 	start := scroll
-	end := start + visibleHeight
+	end := start + tableHeight
 	if end > len(pkgs) {
 		end = len(pkgs)
 	}
@@ -190,8 +189,8 @@ func renderPackageTable(pkgs []model.Package, cursor, scroll, height, width int,
 
 	// Scroll indicator
 	total := len(pkgs)
-	if total > visibleHeight {
-		pct := (scroll + 1) * 100 / total
+	if total > tableHeight {
+		pct := (cursor + 1) * 100 / total
 		indicator := fmt.Sprintf("  %d/%d (%d%%)", cursor+1, total, pct)
 		lines = append(lines, StyleDim.Render(indicator))
 	}


### PR DESCRIPTION
Scroll is just an offset from which the list elements begin rendering. The main motivation for this was that I wanted Vim's ctrl+e and ctrl+y scroll. Note that I haven't added the new key descriptions to the status bar as I'm not quite sure about where they should go. Handles other motions such as g/G and ctrl+d/ctrl+u, as well as search (filtering).

A bit of a wonky implementation because of hard-coded values (visibleHeight). I'd like to discuss how this could be handled better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Selection stays visible while navigating (including page/home/end and movement keys).
  * Viewport height adapts to window size and result changes, with a minimum to avoid empty displays.
  * Filtering and tab switching reset and clamp scroll/cursor so results start predictably when the list changes.
* **Bug Fixes**
  * Fixes jitter and out-of-bounds cursor/scroll after filtering, resizing, or navigation.
* **Tests**
  * Adds comprehensive scrolling tests covering navigation, half-page jumps, resizing, and empty/short lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neur0map/glazepkg/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->